### PR TITLE
SHD-980/fix migration errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ inventory-dev/
 *.zip
 artifacts/
 downloads/
-bundle/
 
 # Harbor / model registry
 k8s-harbor-sa-secret

--- a/installer/internal/config/bundle/bundle.go
+++ b/installer/internal/config/bundle/bundle.go
@@ -1,0 +1,93 @@
+package bundle
+
+import (
+	"fmt"
+
+	"github.com/axem-solutions/ai_platform/installer/internal/progress"
+)
+
+// Prepared contains the bundle data available after successful preparation.
+type Prepared struct {
+	// ImagesDir contains the extracted OCI image archives.
+	ImagesDir string
+
+	// PulumiWorkDir contains the Pulumi projects and stack files from the bundle.
+	PulumiWorkDir string
+
+	// ServiceImages contains service images declared by the bundle.
+	ServiceImages []Image
+
+	// HarborImages contains Harbor images declared by the bundle.
+	HarborImages []Image
+
+	// Models contains models declared by the bundle.
+	Models []Model
+}
+
+// PrepareOptions configures bundle preparation.
+type PrepareOptions struct {
+	// ArchivePath is the path to the mounted installer bundle archive.
+	ArchivePath string
+
+	// Destination is the directory where the bundle is extracted.
+	Destination string
+
+	// Logf receives detailed bundle preparation messages.
+	Logf func(format string, args ...any)
+
+	// Progressf receives bundle extraction progress events.
+	Progressf func(progress.Event)
+}
+
+func (opts PrepareOptions) Validate() error {
+	if opts.ArchivePath == "" {
+		return fmt.Errorf("bundle archive path is required")
+	}
+
+	if opts.Destination == "" {
+		return fmt.Errorf("bundle destination is required")
+	}
+
+	return nil
+}
+
+func Prepare(opts PrepareOptions) (Prepared, error) {
+	if err := opts.Validate(); err != nil {
+		return Prepared{}, fmt.Errorf("invalid opts: %w", err)
+	}
+
+	extracted, err := extractBundle(extractOptions{
+		archivePath:    opts.ArchivePath,
+		destinationDir: opts.Destination,
+		Logf:           opts.Logf,
+		Progressf:      opts.Progressf,
+	})
+	if err != nil {
+		return Prepared{}, fmt.Errorf("extract bundle: %w", err)
+	}
+
+	images, err := readManifest[imageManifest](extracted.ImageManifestPath)
+	if err != nil {
+		return Prepared{}, fmt.Errorf("read image manifest: %w", err)
+	}
+
+	if err := resolveImageSizes(images.Services, extracted.ImagesDir); err != nil {
+		return Prepared{}, fmt.Errorf("resolve service image sizes: %w", err)
+	}
+	if err := resolveImageSizes(images.Harbor, extracted.ImagesDir); err != nil {
+		return Prepared{}, fmt.Errorf("resolve Harbor image sizes: %w", err)
+	}
+
+	models, err := readManifest[modelManifest](extracted.ModelManifestPath)
+	if err != nil {
+		return Prepared{}, fmt.Errorf("read model manifest: %w", err)
+	}
+
+	return Prepared{
+		ImagesDir:     extracted.ImagesDir,
+		PulumiWorkDir: extracted.PulumiWorkDir,
+		ServiceImages: images.Services,
+		HarborImages:  images.Harbor,
+		Models:        models.Models,
+	}, nil
+}

--- a/installer/internal/config/bundle/extract.go
+++ b/installer/internal/config/bundle/extract.go
@@ -1,0 +1,295 @@
+package bundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/axem-solutions/ai_platform/installer/internal/progress"
+)
+
+const (
+	defaultDeploymentDir = "deployments"
+	defaultImageDir      = "images"
+	defaultManifestDir   = "manifests"
+	defaultImageFile     = "images.yml"
+	defaultModelFile     = "models.yml"
+
+	bundleChecksumFile = "checksum.json"
+)
+
+type extractedBundle struct {
+	ImagesDir         string
+	PulumiWorkDir     string
+	ModelManifestPath string
+	ImageManifestPath string
+}
+
+type extractOptions struct {
+	archivePath    string
+	destinationDir string
+	Logf           func(format string, args ...any)
+	Progressf      func(progress.Event)
+}
+
+func bundlePaths(destinationDir string) extractedBundle {
+	return extractedBundle{
+		ImagesDir:         filepath.Join(destinationDir, defaultImageDir),
+		PulumiWorkDir:     filepath.Join(destinationDir, defaultDeploymentDir),
+		ModelManifestPath: filepath.Join(destinationDir, defaultManifestDir, defaultModelFile),
+		ImageManifestPath: filepath.Join(destinationDir, defaultManifestDir, defaultImageFile),
+	}
+}
+
+func (e extractedBundle) Validate() error {
+	if err := checkDir(e.ImagesDir); err != nil {
+		return err
+	}
+
+	if err := checkDir(e.PulumiWorkDir); err != nil {
+		return err
+	}
+
+	if err := checkFile(e.ImageManifestPath); err != nil {
+		return err
+	}
+
+	if err := checkFile(e.ModelManifestPath); err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (opts extractOptions) validate() error {
+	if opts.archivePath == "" {
+		return fmt.Errorf("archive path is required")
+	}
+
+	if opts.destinationDir == "" {
+		return fmt.Errorf("destination directory is required")
+	}
+
+	return nil
+}
+
+func extractBundle(opts extractOptions) (extractedBundle, error) {
+	if err := opts.validate(); err != nil {
+		return extractedBundle{}, fmt.Errorf("invalid extract options: %w", err)
+	}
+
+	if err := untarBundle(opts); err != nil {
+		return extractedBundle{}, fmt.Errorf("extract bundle: %w", err)
+	}
+
+	bundle := bundlePaths(opts.destinationDir)
+
+	if err := bundle.Validate(); err != nil {
+		if err := resetDestination(opts.destinationDir); err != nil {
+			return extractedBundle{}, err
+		}
+		return extractedBundle{}, fmt.Errorf("bundle is not valid: %w", err)
+	}
+
+	return bundle, nil
+}
+
+func untarBundle(opts extractOptions) error {
+	file, err := os.Open(opts.archivePath)
+	if err != nil {
+		return fmt.Errorf("open bundle archive %s: %w", opts.archivePath, err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat bundle archive: %w", err)
+	}
+
+	tracker := progress.NewTracker(
+		progress.PhaseExtracting,
+		filepath.Base(opts.archivePath),
+		info.Size(),
+		0,
+		opts.Progressf,
+	).Throttle(progress.DefaultReportEvery)
+	tracker.Start()
+
+	gzipReader, err := gzip.NewReader(tracker.Reader(file))
+	if err != nil {
+		return fmt.Errorf("open bundle gzip stream: %w", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+
+	return extractTar(tarReader, opts)
+}
+
+func extractTar(tarReader *tar.Reader, opts extractOptions) error {
+	reuse, checksum, err := checksumEntry(tarReader, opts)
+	if err != nil {
+		return fmt.Errorf("check bundle checksum: %w", err)
+	}
+
+	if reuse {
+		return nil
+	}
+
+	if err := resetDestination(opts.destinationDir); err != nil {
+		return err
+	}
+
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("read tar entry: %w", err)
+		}
+
+		targetPath, err := safeTargetPath(opts.destinationDir, header.Name)
+		if err != nil {
+			return fmt.Errorf("safe target path: %w", err)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return fmt.Errorf("create directory %s: %w", targetPath, err)
+			}
+		case tar.TypeReg:
+			if err := extractFile(tarReader, targetPath); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported tar entry %q", header.Name)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(opts.destinationDir, bundleChecksumFile), checksum, 0o644); err != nil {
+		return fmt.Errorf("write bundle checksum: %w", err)
+	}
+
+	return nil
+}
+
+func extractFile(reader io.Reader, targetPath string) error {
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return fmt.Errorf("create parent directory %s: %w", filepath.Dir(targetPath), err)
+	}
+
+	file, err := os.Create(targetPath)
+	if err != nil {
+		return fmt.Errorf("create file %s: %w", targetPath, err)
+	}
+
+	_, copyErr := io.Copy(file, reader)
+	closeErr := file.Close()
+
+	if copyErr != nil {
+		return fmt.Errorf("extract file %s: %w", targetPath, copyErr)
+	}
+
+	if closeErr != nil {
+		return fmt.Errorf("close file %s: %w", targetPath, closeErr)
+	}
+
+	return nil
+}
+
+func checksumEntry(tarReader *tar.Reader, opts extractOptions) (bool, []byte, error) {
+	header, err := tarReader.Next()
+	if err != nil {
+		return false, nil, fmt.Errorf("read checksum entry: %w", err)
+	}
+
+	if filepath.Clean(header.Name) != bundleChecksumFile {
+		return false, nil, fmt.Errorf("%s must be the first bundle entry", bundleChecksumFile)
+	}
+
+	if header.Typeflag != tar.TypeReg {
+		return false, nil, fmt.Errorf("%s must be a regular file", bundleChecksumFile)
+	}
+
+	checksumData, err := io.ReadAll(tarReader)
+	if err != nil {
+		return false, nil, fmt.Errorf("read bundle checksum: %w", err)
+	}
+
+	existingChecksum, err := os.ReadFile(filepath.Join(opts.destinationDir, bundleChecksumFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, checksumData, nil
+		}
+		return false, nil, fmt.Errorf("read extracted checksum: %w", err)
+	}
+
+	return bytes.Equal(checksumData, existingChecksum), checksumData, nil
+
+}
+
+func safeTargetPath(destinationDir, entryName string) (string, error) {
+	if filepath.IsAbs(entryName) {
+		return "", fmt.Errorf("tar entry %q uses an absolute path", entryName)
+	}
+
+	targetPath := filepath.Join(destinationDir, filepath.Clean(entryName))
+
+	relative, err := filepath.Rel(destinationDir, targetPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve tar entry %q: %w", entryName, err)
+	}
+
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("tar entry %q escapes destination directory", entryName)
+	}
+
+	return targetPath, nil
+}
+
+func resetDestination(destinationDir string) error {
+	if err := os.RemoveAll(destinationDir); err != nil {
+		return fmt.Errorf("remove existing bundle %s: %w", destinationDir, err)
+	}
+
+	if err := os.MkdirAll(destinationDir, 0o755); err != nil {
+		return fmt.Errorf("create bundle directory %s: %w", destinationDir, err)
+	}
+
+	return nil
+}
+
+func checkFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat file %s: %w", path, err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("%s is not a file", path)
+	}
+
+	return nil
+}
+
+func checkDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat directory %s: %w", path, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+
+	return nil
+}

--- a/installer/internal/config/bundle/manifest.go
+++ b/installer/internal/config/bundle/manifest.go
@@ -1,0 +1,100 @@
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.yaml.in/yaml/v2"
+)
+
+type Model struct {
+	ID            string       `yaml:"id"`
+	Revision      string       `yaml:"revision"`
+	HarborProject string       `yaml:"harbor_project"`
+	HarborName    string       `yaml:"harbor_name"`
+	HarborTag     string       `yaml:"harbor_tag"`
+	Dependencies  []Dependency `yaml:"dependencies,omitempty"`
+}
+
+type Dependency struct {
+	ID       string `yaml:"id"`
+	Revision string `yaml:"revision"`
+}
+
+type ImageSource string
+
+const (
+	ImageSourceArchive     ImageSource = "archive"
+	ImageSourceDockerHub   ImageSource = "dockerhub"
+	ImageSourceGitHub      ImageSource = "ghcr"
+	ImageSourceNVCR        ImageSource = "nvcr"
+	ImageSourceQuay        ImageSource = "quay"
+	ImageSourceRegistryK8s ImageSource = "registry_k8s"
+)
+
+type Image struct {
+	Source  ImageSource `yaml:"source"`
+	Project string      `yaml:"project"`
+	Name    string      `yaml:"name"`
+	Tag     string      `yaml:"tag"`
+	Size    int64       `yaml:"-"`
+}
+
+type imageManifest struct {
+	Services []Image `yaml:"harbor_upload_images"`
+	Harbor   []Image `yaml:"goharbor_images"`
+}
+
+type modelManifest struct {
+	Models []Model `yaml:"models"`
+}
+
+func readManifest[T any](path string) (T, error) {
+	var manifest T
+
+	file, err := os.Open(path)
+	if err != nil {
+		return manifest, fmt.Errorf("open manifest %s: %w", path, err)
+	}
+	defer file.Close()
+
+	if err := yaml.NewDecoder(file).Decode(&manifest); err != nil {
+		return manifest, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+
+	return manifest, nil
+}
+
+func resolveImageSizes(images []Image, imagesDir string) error {
+	for i := range images {
+		if images[i].Source != ImageSourceArchive {
+			continue
+		}
+
+		archivePath := filepath.Join(imagesDir, images[i].FileName())
+
+		info, err := os.Stat(archivePath)
+		if err != nil {
+			return fmt.Errorf("stat archive for image %s: %w", images[i].Ref(), err)
+		}
+
+		if info.IsDir() {
+			return fmt.Errorf("archive for image %s is not a file: %s", images[i].Ref(), archivePath)
+		}
+
+		images[i].Size = info.Size()
+	}
+
+	return nil
+}
+
+func (i Image) Ref() string {
+	return fmt.Sprintf("%s/%s:%s", i.Project, i.Name, i.Tag)
+}
+
+func (i Image) FileName() string {
+	name := strings.ReplaceAll(i.Name, "/", "-")
+	return fmt.Sprintf("%s-%s.tar", name, i.Tag)
+}

--- a/installer/internal/workflow/stages/pulumi/stacks/names.go
+++ b/installer/internal/workflow/stages/pulumi/stacks/names.go
@@ -13,6 +13,9 @@ const (
 	stackAppShaide       = "shaide"
 	stackCloudHarbor     = "harbor"
 	stackOnPremHarbor    = "OnPrem"
+	stackMonitoring      = "monitoring"
+
+	configNamespaceHarbor = "harbor"
 )
 
 func pulumiConfigKey(projectName, key string) string {


### PR DESCRIPTION
## Type of change

<!-- Select all that apply. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring or maintenance
- [ ] Documentation update

## Related issue

<!-- Use a closing keyword when this pull request resolves an issue, for example: Closes #123. -->

Closes [SHD-980](https://axem.atlassian.net/browse/SHD-980)

## Description

<!-- Explain what changed, why it is needed, and which components or environments are affected. Keep the pull request focused on the related issue. -->
Restores missing migration constants and re-includes the folder that was accidentally excluded, ensuring all required migration assets are committed and available.
## Validation

<!-- List the commands you ran from every affected Go module and their results. Explain any checks that do not apply. -->

- [x] Changed Go files were formatted with `gofmt`.


Additional validation details:

## Deployment and operational impact

<!-- Describe configuration changes, compatibility constraints, migrations, rollout ordering, rollback steps, and infrastructure or operational effects. Write "None" when there are none. -->
None.

## Documentation

<!-- Describe the README or architecture documentation updated in this pull request, or explain why none is needed. -->
None required.
## Checklist

- [ ] I added or updated tests for changed behavior, or explained why tests are not needed.
- [ ] I updated documentation for deployment, configuration, topology, or operational changes.
- [x] My commits follow the Conventional Commits specification.
- [x] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.

## Screenshots

<!-- Add screenshots when they help reviewers understand the change. Remove this section when it does not apply. -->
Not applicable.
## Additional information

<!-- Add any other context that reviewers should know. Remove this section when it does not apply. -->
None.

[SHD-980]: https://axem.atlassian.net/browse/SHD-980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ