### PR TITLE
Shd 922/expose the installed models

### DIFF
--- a/app_serving/README.md
+++ b/app_serving/README.md
@@ -404,6 +404,37 @@ The code validates that:
 
 Mismatches (e.g. `gaie-alma-pro` + `ms-amla-pro`) will produce a clear error at `pulumi preview` time.
 
+## Exposing Installed Models
+
+app_serving does not export a model list. Instead, each model's routable
+Service is labeled with `axem.dev/model-slug`, `axem.dev/model-category`
+(`generative`/`embedder`), and `app.kubernetes.io/part-of=app-serving` (see
+`Model.MetaLabels()` in `internal/config/naming.go`) — the generative path's
+`llmd-gateway-<slug>` ExternalName Service and the embedder path's
+`ms-<slug>-embeddings` ClusterIP Service.
+
+app-shaide grants shaide-server cluster-wide read access to `services` and
+`namespaces` (see `pkg/iac/shaide/internal/platform/k8s-rbac.go`) so it can
+discover this topology by label selector at runtime and pair each Service
+with the model-owned metadata (name, context size, ...) served by vLLM's own
+`/server-info` endpoint — rather than app_serving parsing `values.yaml` to
+rebuild state vLLM already owns. `values.yaml` still configures the model's
+actual deployment; it is no longer a source consumed to describe it.
+
+Two enabled models resolving to the same slug collide on the Kubernetes
+objects they'd create (same `llm-d-<slug>` namespace, same release names),
+so the deploy fails — just at apply time against the cluster, not at plan
+time.
+
+Note this is a different check from the one that used to exist:
+`BuildModelsJSON` rejected duplicate *served* model names (`modelArtifacts.name`
+in `ms-<slug>/values.yaml` — what a client puts in the OpenAI `model`
+field), which is orthogonal to the slug. Two different slugs deploying the
+same underlying model under the same served name will both come up fine
+today — nothing in this repo detects that anymore. Catching it belongs
+with whatever aggregates `/server-info` across models (shaide-server), the
+same place that now owns served-name resolution in the first place.
+
 ## Dependencies
 
 The project uses:
@@ -479,7 +510,7 @@ implementation lives in the shared `pkg` module, at `pkg/iac/serving/`:
 - `main.go`: Compiles the stack binary; delegates to `pkg/iac/serving.DeployAppServing`
 - `pkg/iac/serving/serving.go`: Orchestration — loops over all models in `config.Models`
 - `pkg/iac/serving/internal/config/config.go`: Config loading and convention-based model discovery; returns a single `Config` containing one `Model` entry per enabled model
-- `pkg/iac/serving/internal/config/naming.go`: Release name derivation from slug
+- `pkg/iac/serving/internal/config/naming.go`: Release name derivation from slug, plus `ChatCompletionEndpoint()`/`EmbeddingURL()` and `MetaLabels()` (the labels shaide-server discovers a model's Service by)
 - `pkg/iac/serving/internal/components/*/deploy.go`: Component-specific installation functions (llmd-infra, gaie, modelservice, httproute, embeddingservice)
 - `pkg/iac/serving/internal/platform/secret.go`: Harbor pull secret creation (`harbor-creds`)
 - `pkg/iac/serving/internal/platform/model_storage.go`: PVC + ORAS pull Job creation for `modelSource`

--- a/app_shaide/README.md
+++ b/app_shaide/README.md
@@ -19,7 +19,7 @@ pkg/iac/shaide/
     ├── runtime/context.go                  # DeploymentContext — shared labels + dependency options
     ├── platform/
     │   ├── k8s-serviceaccount.go           # shaide-server ServiceAccount (+ workload-identity annotations)
-    │   ├── k8s-rbac.go                     # ClusterRole/ClusterRoleBinding — cluster-wide pod watch
+    │   ├── k8s-rbac.go                     # ClusterRole/ClusterRoleBinding — cluster-wide pod/service/namespace read
     │   ├── configmap.go                    # shaide-config ConfigMap + shaide-secrets Secret
     │   └── secret.go                       # ghcr-creds pull secret (ghcr.io or Harbor)
     ├── components/
@@ -32,9 +32,9 @@ pkg/iac/shaide/
         ├── provider.go, gcp.go, aws.go, azure.go, on-prem.go, generic.go
 ```
 
-## What Each Component Does
+## What Each File Does
 
-### `main.go`
+### `shaide.go` (package root — `DeployAppShaide`)
 
 Compiles the stack binary and delegates to `shaide.DeployAppShaide(ctx)`.
 
@@ -53,6 +53,10 @@ The stack orchestrator and dependency coordinator:
 - Threads shared dependencies through a `runtime.DeploymentContext` so resources only
   create after their inputs are ready.
 
+### `pkg/iac/shaide/internal/config/config.go`
+
+Loads and types all Pulumi stack config into a single `Config` struct.
+
 ### `pkg/iac/shaide/internal/platform/`
 
 - `k8s-serviceaccount.go`: Creates the ServiceAccount used by `shaide-server`
@@ -60,9 +64,11 @@ The stack orchestrator and dependency coordinator:
   `serviceAccountAnnotations` — a generic map, so the same code handles GKE Workload
   Identity, AKS Workload Identity, EKS IRSA, or nothing at all (on-prem/generic).
 - `k8s-rbac.go`: Creates a cluster-scoped `ClusterRole`/`ClusterRoleBinding` granting
-  `shaide-server`'s ServiceAccount `get`/`list`/`watch` on `pods` **cluster-wide** — this
-  is what lets Shaide observe pod state across every namespace it needs to (its own,
-  `app_serving`'s per-model namespaces, `app_mcp`'s namespace, etc.), not just its own namespace.
+  `shaide-server`'s ServiceAccount `get`/`list`/`watch` on `pods`, `services`, and
+  `namespaces` **cluster-wide** — this is what lets Shaide observe pod state and discover
+  installed-model topology across every namespace it needs to (its own, `app_serving`'s
+  per-model namespaces, `app_mcp`'s namespace, etc.), not just its own namespace. See
+  [Installed Model Discovery](#installed-model-discovery) below.
 - `configmap.go`: Creates the shared `shaide-config` ConfigMap (non-secret runtime
   settings, service discovery) and `shaide-secrets` Secret (`adminAuthKey`, `s3Password`, `jwtSecret`, `sessionSecret`).
 - `secret.go`: Creates `ghcr-creds` (`kubernetes.io/dockerconfigjson`). Authenticates
@@ -79,7 +85,9 @@ The stack orchestrator and dependency coordinator:
   `cloudprovider.Provider`.
 - `controlpanel/deploy.go`: Deploys the control panel as a Deployment (single replica,
   no persistence) with a `ClusterIP` Service on port `3000`. Receives `SESSION_SECRET`
-  from the shared `shaide-secrets` Secret.
+  from the shared `shaide-secrets` Secret. It has no direct knowledge of installed
+  models — it consumes shaide-server's own model API. See
+  [Installed Model Discovery](#installed-model-discovery) below.
 - `webapp/deploy.go`: Deploys the end-user facing web application as a Deployment
   (single replica, no persistence) with a `ClusterIP` Service on port `8787`. Same shape
   as the control panel — internal-only, points at `shaide-server` via
@@ -129,6 +137,29 @@ before the main container starts:
 - Starts the main `rustfs` container after permissions are correct.
 
 This matches RustFS expectations (`0o755`) and avoids runtime permission errors.
+
+## Installed Model Discovery
+
+This stack does not hand the Control Panel a model list. Responsibilities
+are kept with their actual sources:
+
+- **Kubernetes / `app_serving`**: topology and routing. Each model's
+  routable Service (`llmd-gateway-<slug>` for generative,
+  `ms-<slug>-embeddings` for embedders) is labeled with
+  `axem.dev/model-slug`, `axem.dev/model-category`, and
+  `app.kubernetes.io/part-of=app-serving` — see `Model.MetaLabels()` in
+  `pkg/iac/serving/internal/config/naming.go`.
+- **vLLM**: model-owned metadata (name, context size, ...), served by each
+  model's own `/server-info` endpoint.
+- **shaide-server**: combines the two at runtime — discovers model Services
+  cluster-wide via the labels above (`k8s-rbac.go` grants the `services`/
+  `namespaces` read access this needs) and queries each one's `/server-info`
+  — and exposes a stable model API.
+- **Control Panel**: consumes that API only; it has no model-related config
+  or mount of its own.
+
+This stack's only job for installed models, then, is granting shaide-server
+the RBAC to discover them (`k8s-rbac.go`) — it carries no model list.
 
 ## Configuration Source of Truth
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -278,7 +278,7 @@ discovery.kubernetes "pods" { role = "pod" }
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
   # promotes namespace / pod / container / job and AI Platform labels
-  # drops any pod that does not carry axem.ai/platform=ai-platform
+  # drops any pod that does not carry axem.dev/platform=ai-platform
 }
 
 loki.source.kubernetes "pod_logs" {
@@ -302,7 +302,7 @@ loki.write "default" {
 Alloy runs as a DaemonSet with cluster-wide pod discovery, so without filtering it would
 collect logs from every namespace — `kube-system`, `cert-manager`, `ingress-nginx`, the
 monitoring stack itself. A `keep` rule in `discovery.relabel` drops any pod that does not
-carry the `axem.ai/platform=ai-platform` label, scoping ingestion to AI Platform workloads
+carry the `axem.dev/platform=ai-platform` label, scoping ingestion to AI Platform workloads
 only. This reduces Loki storage consumption and eliminates noise in dashboards.
 
 **Noisy log filtering**
@@ -446,7 +446,7 @@ labels. All `__meta_kubernetes_*` discovery labels are internal and dropped auto
 unless a `target_label` rule promotes them.
 
 Rules that use `regex = "(.+)"` are **conditional** — the label is only set when the pod
-actually carries it. Pods without `axem.ai/model-slug` (e.g. app_shaide components) produce
+actually carries it. Pods without `axem.dev/model-slug` (e.g. app_shaide components) produce
 no `model_slug` label and no empty-value noise in Loki.
 
 ### Promoted Labels
@@ -461,10 +461,10 @@ no `model_slug` label and no empty-value noise in Loki.
 | `component` | `app.kubernetes.io/component` | app_shaide | `"server"`, `"console"` |
 | `part_of` | `app.kubernetes.io/part-of` | app_shaide + app_serving | `"app-shaide"`, `"app-serving"` |
 | `managed_by` | `app.kubernetes.io/managed-by` | app_shaide + app_serving | `"pulumi"` |
-| `platform` | `axem.ai/platform` | app_shaide + app_serving | `"ai-platform"` |
-| `model_slug` | `axem.ai/model-slug` | app_serving | `"gpt-oss-20b"` |
-| `model_category` | `axem.ai/model-category` | app_serving | `"generative"`, `"embedder"` |
-| `nodegroup` | `axem.ai/nodegroup` | app_serving | `"rtx6000pro-nodepool"` |
+| `platform` | `axem.dev/platform` | app_shaide + app_serving | `"ai-platform"` |
+| `model_slug` | `axem.dev/model-slug` | app_serving | `"gpt-oss-20b"` |
+| `model_category` | `axem.dev/model-category` | app_serving | `"generative"`, `"embedder"` |
+| `nodegroup` | `axem.dev/nodegroup` | app_serving | `"rtx6000pro-nodepool"` |
 
 `nodegroup` is absent on on-prem pods that use `workload: gpu` as their nodeSelector key
 instead of `nodegroup`.

--- a/installer/internal/workflow/stages/pulumi/stacks/serving.go
+++ b/installer/internal/workflow/stages/pulumi/stacks/serving.go
@@ -100,6 +100,7 @@ func DeployAppServing(rt *core.Runtime) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -268,7 +268,7 @@ discovery.kubernetes "pods" { role = "pod" }
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
   # promotes namespace / pod / container / job and AI Platform labels
-  # drops any pod that does not carry axem.ai/platform=ai-platform
+  # drops any pod that does not carry axem.dev/platform=ai-platform
 }
 
 loki.source.kubernetes "pod_logs" {
@@ -292,7 +292,7 @@ loki.write "default" {
 Alloy runs as a DaemonSet with cluster-wide pod discovery, so without filtering it would
 collect logs from every namespace — `kube-system`, `cert-manager`, `ingress-nginx`, the
 monitoring stack itself. A `keep` rule in `discovery.relabel` drops any pod that does not
-carry the `axem.ai/platform=ai-platform` label, scoping ingestion to AI Platform workloads
+carry the `axem.dev/platform=ai-platform` label, scoping ingestion to AI Platform workloads
 only. This reduces Loki storage consumption and eliminates noise in dashboards.
 
 **Noisy log filtering**
@@ -436,7 +436,7 @@ labels. All `__meta_kubernetes_*` discovery labels are internal and dropped auto
 unless a `target_label` rule promotes them.
 
 Rules that use `regex = "(.+)"` are **conditional** — the label is only set when the pod
-actually carries it. Pods without `axem.ai/model-slug` (e.g. app_shaide components) produce
+actually carries it. Pods without `axem.dev/model-slug` (e.g. app_shaide components) produce
 no `model_slug` label and no empty-value noise in Loki.
 
 ### Promoted Labels
@@ -451,10 +451,10 @@ no `model_slug` label and no empty-value noise in Loki.
 | `component` | `app.kubernetes.io/component` | app_shaide | `"server"`, `"console"` |
 | `part_of` | `app.kubernetes.io/part-of` | app_shaide + app_serving | `"app-shaide"`, `"app-serving"` |
 | `managed_by` | `app.kubernetes.io/managed-by` | app_shaide + app_serving | `"pulumi"` |
-| `platform` | `axem.ai/platform` | app_shaide + app_serving | `"ai-platform"` |
-| `model_slug` | `axem.ai/model-slug` | app_serving | `"gpt-oss-20b"` |
-| `model_category` | `axem.ai/model-category` | app_serving | `"generative"`, `"embedder"` |
-| `nodegroup` | `axem.ai/nodegroup` | app_serving | `"rtx6000pro-nodepool"` |
+| `platform` | `axem.dev/platform` | app_shaide + app_serving | `"ai-platform"` |
+| `model_slug` | `axem.dev/model-slug` | app_serving | `"gpt-oss-20b"` |
+| `model_category` | `axem.dev/model-category` | app_serving | `"generative"`, `"embedder"` |
+| `nodegroup` | `axem.dev/nodegroup` | app_serving | `"rtx6000pro-nodepool"` |
 
 `nodegroup` is absent on on-prem pods that use `workload: gpu` as their nodeSelector key
 instead of `nodegroup`.

--- a/pkg/iac/monitoring/internal/components/alloy/deploy.go
+++ b/pkg/iac/monitoring/internal/components/alloy/deploy.go
@@ -70,30 +70,30 @@ discovery.relabel "pod_logs" {
     target_label  = "managed_by"
   }
 
-  // axem.ai/platform → platform  (set by app_shaide + app_serving)
+  // axem.dev/platform → platform  (set by app_shaide + app_serving)
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_axem_ai_platform"]
+    source_labels = ["__meta_kubernetes_pod_label_axem_dev_platform"]
     regex         = "(.+)"
     target_label  = "platform"
   }
 
-  // axem.ai/model-slug → model_slug  (set by app_serving; absent on app_shaide pods)
+  // axem.dev/model-slug → model_slug  (set by app_serving; absent on app_shaide pods)
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_axem_ai_model_slug"]
+    source_labels = ["__meta_kubernetes_pod_label_axem_dev_model_slug"]
     regex         = "(.+)"
     target_label  = "model_slug"
   }
 
-  // axem.ai/model-category → model_category  (set by app_serving)
+  // axem.dev/model-category → model_category  (set by app_serving)
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_axem_ai_model_category"]
+    source_labels = ["__meta_kubernetes_pod_label_axem_dev_model_category"]
     regex         = "(.+)"
     target_label  = "model_category"
   }
 
-  // axem.ai/nodegroup → nodegroup  (absent on on-prem workload:gpu pods)
+  // axem.dev/nodegroup → nodegroup  (absent on on-prem workload:gpu pods)
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_axem_ai_nodegroup"]
+    source_labels = ["__meta_kubernetes_pod_label_axem_dev_nodegroup"]
     regex         = "(.+)"
     target_label  = "nodegroup"
   }
@@ -101,7 +101,7 @@ discovery.relabel "pod_logs" {
   // Drop pods that don't belong to the AI Platform — keeps kube-system,
   // cert-manager, ingress controllers, and the monitoring stack itself out of Loki.
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_axem_ai_platform"]
+    source_labels = ["__meta_kubernetes_pod_label_axem_dev_platform"]
     regex         = "ai-platform"
     action        = "keep"
   }

--- a/pkg/iac/serving/internal/components/embeddingservice/deploy.go
+++ b/pkg/iac/serving/internal/components/embeddingservice/deploy.go
@@ -22,6 +22,11 @@ func Deploy(ctx *pulumi.Context, dep pulumi.Resource, model appConfig.Model, opt
 		Metadata: &metav1.ObjectMetaArgs{
 			Name:      pulumi.String(svcName),
 			Namespace: pulumi.String(model.Namespace),
+			// Labeled (not just the Namespace) so a client with cluster-wide
+			// Service read access — e.g. shaide-server — can discover this
+			// model's endpoint directly via label selector instead of
+			// reconstructing the naming convention.
+			Labels: model.MetaLabels(),
 		},
 		Spec: &corev1.ServiceSpecArgs{
 			Type: pulumi.String("ClusterIP"),

--- a/pkg/iac/serving/internal/components/llmd-infra/deploy.go
+++ b/pkg/iac/serving/internal/components/llmd-infra/deploy.go
@@ -87,6 +87,11 @@ func Deploy(ctx *pulumi.Context, model appConfig.Model, lldChartPath string, opt
 		Metadata: &metav1.ObjectMetaArgs{
 			Name:      pulumi.String(gatewayServiceName),
 			Namespace: pulumi.String(model.Namespace),
+			// Labeled so a client with cluster-wide Service read access —
+			// e.g. shaide-server — can discover this model's chat-completion
+			// endpoint directly via label selector, without needing to know
+			// the Istio-generated Service naming convention it wraps.
+			Labels: model.MetaLabels(),
 		},
 		Spec: &corev1.ServiceSpecArgs{
 			Type:         pulumi.String("ExternalName"),

--- a/pkg/iac/serving/internal/config/naming.go
+++ b/pkg/iac/serving/internal/config/naming.go
@@ -40,6 +40,20 @@ func (m *Model) EmbeddingServiceName() string {
 	return "ms-" + m.ReleasePostFix() + "-embeddings"
 }
 
+// ChatCompletionEndpoint is the URL a client reaches this model at, through
+// the Istio Gateway. "-istio" is not app_serving's own naming choice — it's
+// how Istio names the Service it auto-provisions for a Gateway API Gateway,
+// confirmed against a real deployed cluster (kubectl get svc).
+func (m *Model) ChatCompletionEndpoint() string {
+	return "http://" + m.GatewayName() + "-istio." + m.Namespace + ".svc.cluster.local/v1/chat/completions"
+}
+
+// EmbeddingURL is the URL a client reaches this embedder model at, direct
+// (no Gateway/GAIE — embedding requests bypass that path entirely).
+func (m *Model) EmbeddingURL() string {
+	return "http://" + m.EmbeddingServiceName() + "." + m.Namespace + ".svc.cluster.local:8200/v1/embeddings"
+}
+
 func (m Model) NodeSelectorMap() pulumi.Map {
 	out := pulumi.Map{}
 	for key, value := range m.NodeSelector {
@@ -66,13 +80,13 @@ func (m Model) Category() string {
 func (m Model) MetaLabels() pulumi.StringMap {
 	labels := pulumi.StringMap{
 		"app.kubernetes.io/part-of": pulumi.String("app-serving"),
-		"axem.ai/platform":          pulumi.String("ai-platform"),
-		"axem.ai/model-name":        pulumi.String(m.ModelName),
-		"axem.ai/model-slug":        pulumi.String(m.Slug),
-		"axem.ai/model-category":    pulumi.String(m.Category()),
+		"axem.dev/platform":         pulumi.String("ai-platform"),
+		"axem.dev/model-name":       pulumi.String(m.ModelName),
+		"axem.dev/model-slug":       pulumi.String(m.Slug),
+		"axem.dev/model-category":   pulumi.String(m.Category()),
 	}
 	if ng := m.NodeSelector["nodegroup"]; ng != "" {
-		labels["axem.ai/nodegroup"] = pulumi.String(ng)
+		labels["axem.dev/nodegroup"] = pulumi.String(ng)
 	}
 	return labels
 }

--- a/pkg/iac/shaide/internal/config/config.go
+++ b/pkg/iac/shaide/internal/config/config.go
@@ -79,22 +79,23 @@ type RustFSEnv struct {
 
 // Config is the typed view of Pulumi stack config used by this stack.
 type Config struct {
-	Namespace                 string
-	NodeSelectorKey           string // label key used for node selection (default: nodegroup)
-	NodeSelector              string // global fallback — applies to all components when no per-component key is set
-	NodeSelectorShaide        string // optional — overrides NodeSelector for shaide-server
-	NodeSelectorControlPanel  string // optional — overrides NodeSelector for control-panel
-	NodeSelectorWebApp        string // optional — overrides NodeSelector for webapp
-	NodeSelectorRustfs        string // optional — overrides NodeSelector for rustfs
-	NodeSelectorQdrant        string // optional — overrides NodeSelector for qdrant
-	CloudProvider             string // informational only — identifies the target platform (e.g. "gcp", "aws", "on-prem")
-	StorageClassName          string // optional — if empty, PVCs use the cluster default StorageClass
-	PVNodeHostname            string // optional — node hostname for hostPath PV nodeAffinity (on-prem only)
-	HarborHostname            string // optional — internal Harbor registry hostname (on-prem only, e.g. harbor.internal.lan)
-	Kubeconfig                string // optional — path to kubeconfig file; empty = use KUBECONFIG env / ~/.kube/config
-	ShaidePVSize              string // optional — shaide-server PV/PVC size (default: 5Gi)
-	RustfsPVSize              string // optional — rustfs PV/PVC size (default: 5Gi)
-	QdrantPVSize              string // optional — qdrant PV/PVC size (default: 5Gi)
+	Namespace                string
+	NodeSelectorKey          string // label key used for node selection (default: nodegroup)
+	NodeSelector             string // global fallback — applies to all components when no per-component key is set
+	NodeSelectorShaide       string // optional — overrides NodeSelector for shaide-server
+	NodeSelectorControlPanel string // optional — overrides NodeSelector for control-panel
+	NodeSelectorWebApp       string // optional — overrides NodeSelector for webapp
+	NodeSelectorRustfs       string // optional — overrides NodeSelector for rustfs
+	NodeSelectorQdrant       string // optional — overrides NodeSelector for qdrant
+	CloudProvider            string // informational only — identifies the target platform (e.g. "gcp", "aws", "on-prem")
+	StorageClassName         string // optional — if empty, PVCs use the cluster default StorageClass
+	PVNodeHostname           string // optional — node hostname for hostPath PV nodeAffinity (on-prem only)
+	HarborHostname           string // optional — internal Harbor registry hostname (on-prem only, e.g. harbor.internal.lan)
+	Kubeconfig               string // optional — path to kubeconfig file; empty = use KUBECONFIG env / ~/.kube/config
+	ShaidePVSize             string // optional — shaide-server PV/PVC size (default: 5Gi)
+	RustfsPVSize             string // optional — rustfs PV/PVC size (default: 5Gi)
+	QdrantPVSize             string // optional — qdrant PV/PVC size (default: 5Gi)
+
 	LBAnnotations             map[string]string
 	ServiceAccountAnnotations map[string]string
 	ServiceAccountName        string

--- a/pkg/iac/shaide/internal/platform/k8s-rbac.go
+++ b/pkg/iac/shaide/internal/platform/k8s-rbac.go
@@ -9,13 +9,23 @@ import (
 )
 
 // CreateShaideRBAC grants shaide-server the Kubernetes API access it needs at runtime.
+//
+// Read access covers pods, services, and namespaces cluster-wide: model
+// namespaces (llm-d-<slug>, created by app-serving) aren't known ahead of
+// time, so this can't be scoped to a fixed set of namespaces via RBAC.
+// shaide-server discovers each model's topology (namespace, routable
+// Service) by listing Services labeled by app-serving (axem.dev/model-slug,
+// axem.dev/model-category — see pkg/iac/serving/internal/config/naming.go's
+// MetaLabels) and reads model-owned metadata directly from vLLM's own
+// /server-info endpoint at each one, rather than app-serving exporting a
+// static model list for shaide to consume.
 func CreateShaideRBAC(
 	ctx *pulumi.Context,
 	cfg appconfig.Config,
 	providerOpt pulumi.ResourceOption,
 ) ([]pulumi.Resource, error) {
-	roleName := "shaide-server-pod-reader"
-	role, err := rbacv1.NewClusterRole(ctx, "shaide-server-pod-reader", &rbacv1.ClusterRoleArgs{
+	roleName := "shaide-server-topology-reader"
+	role, err := rbacv1.NewClusterRole(ctx, "shaide-server-topology-reader", &rbacv1.ClusterRoleArgs{
 		Metadata: &metav1.ObjectMetaArgs{
 			Name: pulumi.String(roleName),
 		},
@@ -24,6 +34,8 @@ func CreateShaideRBAC(
 				ApiGroups: pulumi.StringArray{pulumi.String("")},
 				Resources: pulumi.StringArray{
 					pulumi.String("pods"),
+					pulumi.String("services"),
+					pulumi.String("namespaces"),
 				},
 				Verbs: pulumi.StringArray{
 					pulumi.String("get"),
@@ -37,7 +49,7 @@ func CreateShaideRBAC(
 		return nil, err
 	}
 
-	binding, err := rbacv1.NewClusterRoleBinding(ctx, "shaide-server-pod-reader-binding", &rbacv1.ClusterRoleBindingArgs{
+	binding, err := rbacv1.NewClusterRoleBinding(ctx, "shaide-server-topology-reader-binding", &rbacv1.ClusterRoleBindingArgs{
 		RoleRef: &rbacv1.RoleRefArgs{
 			ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
 			Kind:     pulumi.String("ClusterRole"),

--- a/pkg/iac/shaide/internal/runtime/context.go
+++ b/pkg/iac/shaide/internal/runtime/context.go
@@ -47,7 +47,7 @@ func NewDeploymentContext(
 				"app.kubernetes.io/part-of":    pulumi.String("app-shaide"),
 				"app.kubernetes.io/component":  pulumi.String(component),
 				"app.kubernetes.io/managed-by": pulumi.String("pulumi"),
-				"axem.ai/platform":             pulumi.String("ai-platform"),
+				"axem.dev/platform":            pulumi.String("ai-platform"),
 			}
 		},
 	}


### PR DESCRIPTION
## Type Of Change
New feature (non-breaking change which adds functionality).

### Checklist:
- [ ] I have thoroughly tested my modifications and all potential side effects.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: [SHD-922](https://axem.atlassian.net/browse/SHD-922)

## Description
Expose the installed model list from `app-serving` to `app-shaide` so the Control Panel can read a generated `vllm-config.json`.

Changes included:

- `app-serving` now parses each model's `values.yaml` for `modelArtifacts.name` and `--max-model-len`, builds endpoint URLs, guards against duplicate model names, and exports the assembled model config as the Pulumi `models` stack output.
- Embedder models now include `embedding-metadata.yaml`; real `vectorSize` values still need to be filled in before final validation.
- The installer now carries the `app-serving` `models` output into `app-shaide` as `modelsJSON`, matching the existing in-process handoff pattern used for `gatewayHostname`.
- Recreate mode now also captures the fresh `models` output after redeploying `app-serving`.
- `app-shaide` now creates a `vllm-config` `ConfigMap`, mounts it into the Control Panel pod at the configurable `controlPanelVllmConfigMountPath`, sets `VLLM_CONFIG_PATH`, and adds a pod-template hash annotation so the Control Panel restarts when the model list changes.
- Documentation was updated for `app-serving`, `app-shaide`, the current `app-shaide` source layout, and the Control Panel port.

Dependencies:

- Adds `gopkg.in/yaml.v3` as a direct dependency because `app-serving` now parses model `values.yaml` files directly.

## How Has This Been Tested?
Not tested yet.

Planned validation:

- [ ] Fill in real `vectorSize` for every enabled embedder currently set to `TBD`.
- [ ] `cd app_serving/deployments && pulumi up`
- [ ] `pulumi stack output models > /tmp/models.json`
- [ ] `cd ../../app_shaide/deployments && pulumi config set modelsJSON -- "$(cat /tmp/models.json)"`
- [ ] `pulumi up` on `app_shaide` and confirm the `vllm-config` `ConfigMap` is created with the expected content.
- [ ] `kubectl exec` into the Control Panel pod and confirm the file exists at the configured path, has the right content, and `$VLLM_CONFIG_PATH` matches.

## Additional info
The default Control Panel mount path remains `/etc/shaide/vllm-config.json` unless `controlPanelVllmConfigMountPath` is explicitly configured.

[SHD-922]: https://axem.atlassian.net/browse/SHD-922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ