### PR TITLE
feat(app_shaide): add JWT_SECRET env var

### DIFF
--- a/app_shaide/README.md
+++ b/app_shaide/README.md
@@ -64,7 +64,7 @@ The stack orchestrator and dependency coordinator:
   is what lets Shaide observe pod state across every namespace it needs to (its own,
   `app_serving`'s per-model namespaces, `app_mcp`'s namespace, etc.), not just its own namespace.
 - `configmap.go`: Creates the shared `shaide-config` ConfigMap (non-secret runtime
-  settings, service discovery) and `shaide-secrets` Secret (`adminAuthKey`, `s3Password`).
+  settings, service discovery) and `shaide-secrets` Secret (`adminAuthKey`, `s3Password`, `jwtSecret`).
 - `secret.go`: Creates `ghcr-creds` (`kubernetes.io/dockerconfigjson`). Authenticates
   against `ghcr.io` using `ghcrUser`/`ghcrToken` — or, when `harborHostname` is set,
   against that internal Harbor registry instead, using the same two config keys.
@@ -140,7 +140,7 @@ All parameters are defined in the active stack's `deployments/Pulumi.<stack>.yam
   `TRIAL` env var — only the `trial` stack sets it to `TRUE`).
 - RustFS console exposure (`rustfsConsoleEnabled`).
 - MCP integration (`mcpNamespace`, optional — see [MCP Integration](#mcp-integration-optional)).
-- Secrets (`ghcrToken`, `adminAuthKey`, `s3Password`).
+- Secrets (`ghcrToken`, `adminAuthKey`, `s3Password`, `jwtSecret`).
 
 The `nodeSelector` value must match a `nodegroup` label on the target node pool (e.g. `shaide-nodepool`).
 
@@ -148,7 +148,7 @@ The `nodeSelector` value must match a `nodegroup` label on the target node pool 
 
 - Kubernetes context points to the target cluster.
 - Pulumi stack is selected for this project.
-- Required secrets are set (`ghcrToken`, `adminAuthKey`, `s3Password`).
+- Required secrets are set (`ghcrToken`, `adminAuthKey`, `s3Password`, `jwtSecret`).
 
 ## Workload Identity
 

--- a/app_shaide/deployments/Pulumi.TEMPLATE.yaml
+++ b/app_shaide/deployments/Pulumi.TEMPLATE.yaml
@@ -37,6 +37,7 @@
 #     ghcrToken     — GHCR PAT (read:packages) or Harbor robot secret (see harborHostname below)
 #     adminAuthKey  — shaide-server admin auth key
 #     s3Password    — RustFS S3 credential (paired with s3User above)
+#     jwtSecret     — shaide-server JWT signing secret; random string, at least 32 characters
 #
 # Optional config:
 #   kubeconfig        — path to kubeconfig file; omit to use KUBECONFIG env / ~/.kube/config
@@ -108,6 +109,7 @@
 #   pulumi config set --secret ghcrToken <token-or-harbor-robot-secret>
 #   pulumi config set --secret adminAuthKey <value>
 #   pulumi config set --secret s3Password <value>
+#   pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
 config:
   app-shaide:namespace: app-shaide
   app-shaide:shaideServiceAccountName: shaide-server
@@ -180,10 +182,13 @@ config:
   # --- Secrets (encrypted, set per stack via CLI) ---
   #   pulumi config set --secret adminAuthKey <value>
   #   pulumi config set --secret s3Password <value>
+  #   pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
   app-shaide:adminAuthKey:
     secure: <run `pulumi config set --secret adminAuthKey <value>`>
   app-shaide:s3Password:
     secure: <run `pulumi config set --secret s3Password <value>`>
+  app-shaide:jwtSecret:
+    secure: <run `pulumi config set --secret jwtSecret <random-string-at-least-32-chars>`>
 #
 # Managed by Pulumi.
 # Do not edit or remove the following line — required to decrypt secret config values.

--- a/app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml
+++ b/app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml
@@ -145,7 +145,13 @@ config:
   #   pulumi stack select aks-axem-trial-westeurope
   #   pulumi config set --secret adminAuthKey <value>
   #   pulumi config set --secret s3Password <value>
+  #   pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
   # ==========================================================================
+  # jwtSecret has no encrypted value here yet — this file's ciphertext is tied
+  # to this stack's own encryptionsalt, so it can't be hand-written like the
+  # other secure: blocks above. Run the CLI command above against this stack
+  # before the next `pulumi up`, or the shaide-server deploy will fail on the
+  # new required jwtSecret config key.
   app-shaide:adminAuthKey:
     secure: v1:ml0cTXNfKRO5Y0G6:+oOUq0qVZWl7/ClSpizb3Hf5TjfG
   app-shaide:s3Password:

--- a/installer/docs/development/STACK_FILES_CONFIG.md
+++ b/installer/docs/development/STACK_FILES_CONFIG.md
@@ -198,6 +198,7 @@ Injected as environment variables via ConfigMap into the shaide-server pod.
 |---|---|---|
 | `app_shaide:adminAuthKey` | **Secret** | Shaide admin authentication key. Set via: `pulumi config set --secret app_shaide:adminAuthKey <value>`. |
 | `app_shaide:s3Password` | **Secret** | RustFS (S3) admin password. Set via: `pulumi config set --secret app_shaide:s3Password <value>`. |
+| `app_shaide:jwtSecret` | **Secret** | shaide-server JWT signing secret; random string, at least 32 characters. Set via: `pulumi config set --secret app_shaide:jwtSecret <value>`. |
 
 ---
 
@@ -288,4 +289,5 @@ These are never committed in plain text. Set them with `pulumi config set --secr
 | `app_shaide` | `app_shaide:ghcrToken` | After `ansible-playbook harbor_setup.yml` |
 | `app_shaide` | `app_shaide:adminAuthKey` | Before `pulumi up` |
 | `app_shaide` | `app_shaide:s3Password` | Before `pulumi up` |
+| `app_shaide` | `app_shaide:jwtSecret` | Before `pulumi up` |
 | `app-serving` | `app-serving:harborToken` | After `ansible-playbook harbor_setup.yml` |

--- a/pkg/iac/shaide/internal/config/config.go
+++ b/pkg/iac/shaide/internal/config/config.go
@@ -66,6 +66,7 @@ type AppEnv struct {
 type AppSecrets struct {
 	AdminAuthKey pulumi.StringOutput
 	S3Password   pulumi.StringOutput
+	JWTSecret    pulumi.StringOutput
 }
 
 type RustFSEnv struct {
@@ -190,6 +191,7 @@ func Load(ctx *pulumi.Context) Config {
 		Secrets: AppSecrets{
 			AdminAuthKey: cfg.RequireSecret("adminAuthKey"),
 			S3Password:   cfg.RequireSecret("s3Password"),
+			JWTSecret:    cfg.RequireSecret("jwtSecret"),
 		},
 	}
 }

--- a/pkg/iac/shaide/internal/platform/configmap.go
+++ b/pkg/iac/shaide/internal/platform/configmap.go
@@ -5,6 +5,7 @@
 //
 //	pulumi config set --secret adminAuthKey <value>
 //	pulumi config set --secret s3Password <value>
+//	pulumi config set --secret jwtSecret <value>   (random string, at least 32 characters)
 package platform
 
 import (
@@ -57,6 +58,7 @@ func CreateAppShaideConfig(ctx *pulumi.Context, cfg appconfig.Config, providerOp
 	secretData := pulumi.StringMap{
 		"ADMIN_AUTH_KEY": cfg.Secrets.AdminAuthKey,
 		"S3_PASSWORD":    cfg.Secrets.S3Password,
+		"JWT_SECRET":     cfg.Secrets.JWTSecret,
 	}
 
 	shaideSecrets, err := corev1.NewSecret(ctx, "shaide-secrets", &corev1.SecretArgs{


### PR DESCRIPTION
## Type of change

- [x] New feature

## Related issue

Closes [SHD-991](https://axem.atlassian.net/browse/SHD-991)

## Description

Adds `jwtSecret` as a required Pulumi stack secret for `app_shaide` and injects it into the `shaide-secrets` Kubernetes Secret as `JWT_SECRET` for `shaide-server`.

This keeps the JWT signing secret managed through the same encrypted Pulumi config path as `adminAuthKey` and `s3Password`, instead of relying on an undeclared or external value.

The PR also updates the app Shaide stack template, app README, and stack-file configuration docs so new and existing deployments know to provide:

```sh
pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
```

The existing `aks-kalmannemeth-westeurope` stack file is intentionally marked as needing that secret to be set before its next `pulumi up`, because its encrypted value must be written by Pulumi using the stack's own `encryptionsalt`.

## Validation

- [x] Changed Go files were formatted with `gofmt`.
- [x] `go test ./...` passed in every affected Go module.

Additional validation details:

- Ran `gofmt -w iac/shaide/internal/config/config.go iac/shaide/internal/platform/configmap.go` from `pkg`; no diff remained afterward.
- Ran `go test ./...` from `pkg`; all packages passed.
- Ran `git show --check 47692a87e592f92a18a9980f008f810eab262f80`; no whitespace errors reported.

## Deployment and operational impact

Existing `app_shaide` stacks must set the new required secret before the next deployment:

```sh
pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
```

Without this config value, `pulumi up` for `app_shaide` will fail while loading required config. After it is set, Pulumi will update `shaide-secrets` to include `JWT_SECRET`, and the `shaide-server` workload can consume it from the existing Secret.

Rollback is to revert this change and remove any dependency on `JWT_SECRET` from the deployed `shaide-server` version. The encrypted Pulumi config entry can remain in the stack file if unused.

## Documentation

Updated:

- `app_shaide/deployments/Pulumi.TEMPLATE.yaml`
- `app_shaide/README.md`
- `installer/docs/development/STACK_FILES_CONFIG.md`
- `app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml` with an operator note for the existing stack

## Checklist

- [x] I added or updated tests for changed behavior, or explained why tests are not needed.
- [x] I updated documentation for deployment, configuration, topology, or operational changes.
- [x] My commits follow the Conventional Commits specification.
- [ ] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.


[SHD-991]: https://axem.atlassian.net/browse/SHD-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ