### PR TITLE
Shd 998/add the session secret env var

### DIFF
--- a/app_shaide/README.md
+++ b/app_shaide/README.md
@@ -64,7 +64,7 @@ The stack orchestrator and dependency coordinator:
   is what lets Shaide observe pod state across every namespace it needs to (its own,
   `app_serving`'s per-model namespaces, `app_mcp`'s namespace, etc.), not just its own namespace.
 - `configmap.go`: Creates the shared `shaide-config` ConfigMap (non-secret runtime
-  settings, service discovery) and `shaide-secrets` Secret (`adminAuthKey`, `s3Password`, `jwtSecret`).
+  settings, service discovery) and `shaide-secrets` Secret (`adminAuthKey`, `s3Password`, `jwtSecret`, `sessionSecret`).
 - `secret.go`: Creates `ghcr-creds` (`kubernetes.io/dockerconfigjson`). Authenticates
   against `ghcr.io` using `ghcrUser`/`ghcrToken` — or, when `harborHostname` is set,
   against that internal Harbor registry instead, using the same two config keys.
@@ -78,7 +78,8 @@ The stack orchestrator and dependency coordinator:
   `lbAnnotations`. Delegates cloud-specific post-deploy resources to the active
   `cloudprovider.Provider`.
 - `controlpanel/deploy.go`: Deploys the control panel as a Deployment (single replica,
-  no persistence) with a `ClusterIP` Service on port `3000`.
+  no persistence) with a `ClusterIP` Service on port `3000`. Receives `SESSION_SECRET`
+  from the shared `shaide-secrets` Secret.
 - `webapp/deploy.go`: Deploys the end-user facing web application as a Deployment
   (single replica, no persistence) with a `ClusterIP` Service on port `8787`. Same shape
   as the control panel — internal-only, points at `shaide-server` via
@@ -140,7 +141,7 @@ All parameters are defined in the active stack's `deployments/Pulumi.<stack>.yam
   `TRIAL` env var — only the `trial` stack sets it to `TRUE`).
 - RustFS console exposure (`rustfsConsoleEnabled`).
 - MCP integration (`mcpNamespace`, optional — see [MCP Integration](#mcp-integration-optional)).
-- Secrets (`ghcrToken`, `adminAuthKey`, `s3Password`, `jwtSecret`).
+- Secrets (`ghcrToken`, `adminAuthKey`, `s3Password`, `jwtSecret`, `sessionSecret`).
 
 The `nodeSelector` value must match a `nodegroup` label on the target node pool (e.g. `shaide-nodepool`).
 
@@ -148,7 +149,7 @@ The `nodeSelector` value must match a `nodegroup` label on the target node pool 
 
 - Kubernetes context points to the target cluster.
 - Pulumi stack is selected for this project.
-- Required secrets are set (`ghcrToken`, `adminAuthKey`, `s3Password`, `jwtSecret`).
+- Required secrets are set (`ghcrToken`, `adminAuthKey`, `s3Password`, `jwtSecret`, `sessionSecret`).
 
 ## Workload Identity
 

--- a/app_shaide/deployments/Pulumi.TEMPLATE.yaml
+++ b/app_shaide/deployments/Pulumi.TEMPLATE.yaml
@@ -38,6 +38,7 @@
 #     adminAuthKey  — shaide-server admin auth key
 #     s3Password    — RustFS S3 credential (paired with s3User above)
 #     jwtSecret     — shaide-server JWT signing secret; random string, at least 32 characters
+#     sessionSecret — control-panel session signing secret; random string, at least 32 characters
 #
 # Optional config:
 #   kubeconfig        — path to kubeconfig file; omit to use KUBECONFIG env / ~/.kube/config
@@ -110,6 +111,7 @@
 #   pulumi config set --secret adminAuthKey <value>
 #   pulumi config set --secret s3Password <value>
 #   pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
+#   pulumi config set --secret sessionSecret <random-string-at-least-32-chars>
 config:
   app-shaide:namespace: app-shaide
   app-shaide:shaideServiceAccountName: shaide-server
@@ -183,12 +185,15 @@ config:
   #   pulumi config set --secret adminAuthKey <value>
   #   pulumi config set --secret s3Password <value>
   #   pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
+  #   pulumi config set --secret sessionSecret <random-string-at-least-32-chars>
   app-shaide:adminAuthKey:
     secure: <run `pulumi config set --secret adminAuthKey <value>`>
   app-shaide:s3Password:
     secure: <run `pulumi config set --secret s3Password <value>`>
   app-shaide:jwtSecret:
     secure: <run `pulumi config set --secret jwtSecret <random-string-at-least-32-chars>`>
+  app-shaide:sessionSecret:
+    secure: <run `pulumi config set --secret sessionSecret <random-string-at-least-32-chars>`>
 #
 # Managed by Pulumi.
 # Do not edit or remove the following line — required to decrypt secret config values.

--- a/app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml
+++ b/app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml
@@ -146,12 +146,13 @@ config:
   #   pulumi config set --secret adminAuthKey <value>
   #   pulumi config set --secret s3Password <value>
   #   pulumi config set --secret jwtSecret <random-string-at-least-32-chars>
+  #   pulumi config set --secret sessionSecret <random-string-at-least-32-chars>
   # ==========================================================================
-  # jwtSecret has no encrypted value here yet — this file's ciphertext is tied
-  # to this stack's own encryptionsalt, so it can't be hand-written like the
-  # other secure: blocks above. Run the CLI command above against this stack
-  # before the next `pulumi up`, or the shaide-server deploy will fail on the
-  # new required jwtSecret config key.
+  # jwtSecret and sessionSecret have no encrypted value here yet — this file's
+  # ciphertext is tied to this stack's own encryptionsalt, so they can't be
+  # hand-written like the other secure: blocks above. Run the CLI commands
+  # above against this stack before the next `pulumi up`, or the shaide-server
+  # / control-panel deploy will fail on the new required config keys.
   app-shaide:adminAuthKey:
     secure: v1:ml0cTXNfKRO5Y0G6:+oOUq0qVZWl7/ClSpizb3Hf5TjfG
   app-shaide:s3Password:

--- a/installer/docs/development/STACK_FILES_CONFIG.md
+++ b/installer/docs/development/STACK_FILES_CONFIG.md
@@ -199,6 +199,7 @@ Injected as environment variables via ConfigMap into the shaide-server pod.
 | `app_shaide:adminAuthKey` | **Secret** | Shaide admin authentication key. Set via: `pulumi config set --secret app_shaide:adminAuthKey <value>`. |
 | `app_shaide:s3Password` | **Secret** | RustFS (S3) admin password. Set via: `pulumi config set --secret app_shaide:s3Password <value>`. |
 | `app_shaide:jwtSecret` | **Secret** | shaide-server JWT signing secret; random string, at least 32 characters. Set via: `pulumi config set --secret app_shaide:jwtSecret <value>`. |
+| `app_shaide:sessionSecret` | **Secret** | control-panel session signing secret; random string, at least 32 characters. Set via: `pulumi config set --secret app_shaide:sessionSecret <value>`. |
 
 ---
 
@@ -290,4 +291,5 @@ These are never committed in plain text. Set them with `pulumi config set --secr
 | `app_shaide` | `app_shaide:adminAuthKey` | Before `pulumi up` |
 | `app_shaide` | `app_shaide:s3Password` | Before `pulumi up` |
 | `app_shaide` | `app_shaide:jwtSecret` | Before `pulumi up` |
+| `app_shaide` | `app_shaide:sessionSecret` | Before `pulumi up` |
 | `app-serving` | `app-serving:harborToken` | After `ansible-playbook harbor_setup.yml` |

--- a/pkg/iac/shaide/internal/components/controlpanel/deploy.go
+++ b/pkg/iac/shaide/internal/components/controlpanel/deploy.go
@@ -61,6 +61,15 @@ func Deploy(ctx *pulumi.Context, deps *runtime.DeploymentContext, cfg appconfig.
 									Name:  pulumi.String("SHAIDE_SERVER_PORT"),
 									Value: pulumi.String("80"),
 								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("SESSION_SECRET"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										SecretKeyRef: &corev1.SecretKeySelectorArgs{
+											Name: pulumi.String("shaide-secrets"),
+											Key:  pulumi.String("SESSION_SECRET"),
+										},
+									},
+								},
 							},
 							Ports: corev1.ContainerPortArray{
 								&corev1.ContainerPortArgs{

--- a/pkg/iac/shaide/internal/config/config.go
+++ b/pkg/iac/shaide/internal/config/config.go
@@ -64,9 +64,10 @@ type AppEnv struct {
 }
 
 type AppSecrets struct {
-	AdminAuthKey pulumi.StringOutput
-	S3Password   pulumi.StringOutput
-	JWTSecret    pulumi.StringOutput
+	AdminAuthKey  pulumi.StringOutput
+	S3Password    pulumi.StringOutput
+	JWTSecret     pulumi.StringOutput
+	SessionSecret pulumi.StringOutput
 }
 
 type RustFSEnv struct {
@@ -189,9 +190,10 @@ func Load(ctx *pulumi.Context) Config {
 			WebhookQueueDirShaide: cfg.Require("rustfsNotifyWebhookQueueDirShaide"),
 		},
 		Secrets: AppSecrets{
-			AdminAuthKey: cfg.RequireSecret("adminAuthKey"),
-			S3Password:   cfg.RequireSecret("s3Password"),
-			JWTSecret:    cfg.RequireSecret("jwtSecret"),
+			AdminAuthKey:  cfg.RequireSecret("adminAuthKey"),
+			S3Password:    cfg.RequireSecret("s3Password"),
+			JWTSecret:     cfg.RequireSecret("jwtSecret"),
+			SessionSecret: cfg.RequireSecret("sessionSecret"),
 		},
 	}
 }

--- a/pkg/iac/shaide/internal/platform/configmap.go
+++ b/pkg/iac/shaide/internal/platform/configmap.go
@@ -5,7 +5,8 @@
 //
 //	pulumi config set --secret adminAuthKey <value>
 //	pulumi config set --secret s3Password <value>
-//	pulumi config set --secret jwtSecret <value>   (random string, at least 32 characters)
+//	pulumi config set --secret jwtSecret <value>       (random string, at least 32 characters)
+//	pulumi config set --secret sessionSecret <value>   (random string, at least 32 characters)
 package platform
 
 import (
@@ -59,6 +60,7 @@ func CreateAppShaideConfig(ctx *pulumi.Context, cfg appconfig.Config, providerOp
 		"ADMIN_AUTH_KEY": cfg.Secrets.AdminAuthKey,
 		"S3_PASSWORD":    cfg.Secrets.S3Password,
 		"JWT_SECRET":     cfg.Secrets.JWTSecret,
+		"SESSION_SECRET": cfg.Secrets.SessionSecret,
 	}
 
 	shaideSecrets, err := corev1.NewSecret(ctx, "shaide-secrets", &corev1.SecretArgs{


### PR DESCRIPTION
## Type of change
- [x] New feature

## Related issue

Closes [SHD-998](https://axem.atlassian.net/browse/SHD-998)

## Description

Adds `sessionSecret` as a required `app_shaide` Pulumi stack secret and injects it into the shared `shaide-secrets` Kubernetes Secret as `SESSION_SECRET`.

The control-panel Deployment now reads `SESSION_SECRET` from `shaide-secrets` via `secretKeyRef`, giving the control panel an explicitly managed session signing secret instead of relying on implicit or missing runtime configuration.

Affected areas:

- `app_shaide` Pulumi config loading now requires `sessionSecret`.
- `shaide-secrets` now contains `SESSION_SECRET`.
- The control-panel container now receives `SESSION_SECRET`.
- Stack templates and configuration documentation now describe the new secret.
- The existing `aks-kalmannemeth-westeurope` stack is flagged as needing the secret set before its next `pulumi up`.

## Validation

- [x] Changed Go files were formatted with `gofmt`.
- [x] `go test ./...` passed in every affected Go module.

Additional validation details:

- `gofmt -l pkg/iac/shaide/internal/components/controlpanel/deploy.go pkg/iac/shaide/internal/config/config.go pkg/iac/shaide/internal/platform/configmap.go` returned no files.
- `GOCACHE=/tmp/codex-gocache go test ./...` passed from `/home/nemethk/DevOps/Git/shaide/pkg`.

## Deployment and operational impact

Before the next `pulumi up` for any `app_shaide` stack, set the new required secret:

```sh
pulumi config set --secret sessionSecret <random-string-at-least-32-chars>
```

Without this config value, the Pulumi deployment will fail while loading required stack configuration.

Rollout order:

1. Set `sessionSecret` in each affected Pulumi stack.
2. Run `pulumi up` for `app_shaide`.
3. Verify the control-panel pod starts with `SESSION_SECRET` populated from `shaide-secrets`.

Rollback impact: reverting this change removes the `SESSION_SECRET` requirement from the Pulumi program and stops injecting it into the control-panel container. The encrypted stack config value can remain present without affecting older code.

## Documentation

Updated:

- `app_shaide/deployments/Pulumi.TEMPLATE.yaml`
- `app_shaide/README.md`
- `installer/docs/development/STACK_FILES_CONFIG.md`

The docs now list `sessionSecret` with the other required `app_shaide` secrets and include the `pulumi config set --secret` command.

## Checklist

- [x] I added or updated tests for changed behavior, or explained why tests are not needed.
- [x] I updated documentation for deployment, configuration, topology, or operational changes.
- [x] My commits follow the Conventional Commits specification.
- [ ] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.

Tests were not added because this change only requires a new Pulumi secret config value, maps it into the existing Kubernetes Secret, and wires it into the control-panel environment.

Commit message follows Conventional Commits: `feat(app_shaide): add SESSION_SECRET env var to control_panel`.

The commit does not include a `Signed-off-by` trailer.

No Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets are included. The stack file only documents that the secret must be set with `pulumi config set --secret`.

## Screenshots

Not applicable.

## Additional information

The existing stack file cannot be hand-edited with a valid encrypted `sessionSecret` value because ciphertext is tied to the stack's own `encryptionsalt`. Run the documented Pulumi CLI command against the target stack before deployment.


[SHD-998]: https://axem.atlassian.net/browse/SHD-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ