### PR TITLE
feat: replace nodeSelector with nodeAffinity across app_serving, app_…

### DIFF
--- a/app_mcp/internal/components/mcpdeployment/deploy.go
+++ b/app_mcp/internal/components/mcpdeployment/deploy.go
@@ -118,7 +118,7 @@ func Deploy(ctx *pulumi.Context, ds appconfig.Datasource, cfg appconfig.Config, 
 
 	mainContainer := buildMainContainer(name, ds.Image, caTrustEnvVar, caConfigMapName, port, imagePullPolicy, healthPath, cpuRequest, memoryRequest, cpuLimit, memoryLimit, startupProbeFailureThreshold, ds.DisableProbes, ds.Args, ds.Env, ds.SecretEnv, cfg)
 	volumes := buildVolumes(caConfigMapName)
-	nodeSelector := buildNodeSelector(cfg.NodeSelectorKey, resolveStr(ds.NodeSelector, cfg.NodeSelector))
+	nodeAffinity := buildNodeAffinity(cfg.NodeSelectorKey, resolveStr(ds.NodeSelector, cfg.NodeSelector))
 	imagePullSecrets := buildImagePullSecrets(cfg.ImagePullSecrets)
 
 	deployment, err := appsv1.NewDeployment(ctx, name, &appsv1.DeploymentArgs{
@@ -148,7 +148,7 @@ func Deploy(ctx *pulumi.Context, ds appconfig.Datasource, cfg appconfig.Config, 
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector:     nodeSelector,
+					Affinity:         nodeAffinity,
 					ImagePullSecrets: imagePullSecrets,
 					Containers:       corev1.ContainerArray{mainContainer},
 					Volumes:          volumes,
@@ -183,11 +183,27 @@ func Deploy(ctx *pulumi.Context, ds appconfig.Datasource, cfg appconfig.Config, 
 	return err
 }
 
-func buildNodeSelector(key, value string) pulumi.StringMap {
+func buildNodeAffinity(key, value string) *corev1.AffinityArgs {
 	if key == "" || value == "" {
 		return nil
 	}
-	return pulumi.StringMap{key: pulumi.String(value)}
+	return &corev1.AffinityArgs{
+		NodeAffinity: &corev1.NodeAffinityArgs{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelectorArgs{
+				NodeSelectorTerms: corev1.NodeSelectorTermArray{
+					&corev1.NodeSelectorTermArgs{
+						MatchExpressions: corev1.NodeSelectorRequirementArray{
+							&corev1.NodeSelectorRequirementArgs{
+								Key:      pulumi.String(key),
+								Operator: pulumi.String("In"),
+								Values:   pulumi.StringArray{pulumi.String(value)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func buildImagePullSecrets(names []string) corev1.LocalObjectReferenceArray {

--- a/app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml
+++ b/app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml
@@ -44,11 +44,13 @@ config:
   # ==========================================================================
   app-shaide:shaideServiceAccountName: shaide-server
   # ==========================================================================
-  # Node selector (matches node pool label "nodegroup: <value>")
+  # Node affinity (soft preference — matches node label "axem.dev/workload-cpu: true")
   # infra/azure/03_cluster/deployments/Pulumi.kalmannemeth-westeurope.yaml defines a
-  # "shaide" node pool (cpu-standard, max 3) — matches it explicitly.
+  # "shaide" node pool (cpu-standard, max 3), labeled axem.dev/workload-cpu — preferred,
+  # but app_shaide can still schedule elsewhere if that pool is unavailable.
   # ==========================================================================
-  app-shaide:nodeSelector: cpu-standard
+  app-shaide:nodeSelectorKey: axem.dev/workload-cpu
+  app-shaide:nodeSelector: "true"
   # ==========================================================================
   # Storage — AKS uses Azure Disk CSI dynamic provisioning.
   # The default StorageClass (managed-csi) is used when storageClassName is omitted.

--- a/docs/architecture/application-layer.md
+++ b/docs/architecture/application-layer.md
@@ -148,7 +148,10 @@ All parameters are defined in the active stack's `deployments/Pulumi.<stack>.yam
 - MCP integration (`mcpNamespace`, optional — see [MCP Integration](#mcp-integration-optional)).
 - Secrets (`ghcrToken`, `adminAuthKey`, `s3Password`).
 
-The `nodeSelector` value must match a `nodegroup` label on the target node pool (e.g. `shaide-nodepool`).
+The `nodeSelector` value is rendered as a soft (preferred, not required) `nodeAffinity` for a
+`nodegroup` label on the target node pool (e.g. `shaide-nodepool`) — components prefer a
+matching node but can still schedule elsewhere if none is available. Each component also gets
+a soft `podAntiAffinity` spreading its own replicas across nodes.
 
 ## Prereqs
 

--- a/docs/architecture/model-deployment-flow.md
+++ b/docs/architecture/model-deployment-flow.md
@@ -226,8 +226,9 @@ Deploys:
 Additionally creates two plain Kubernetes resources:
 - An `ExternalName` Service (`llmd-gateway-<slug>`) resolving to the gateway's in-cluster
   FQDN — used by `app_shaide` to reach the inference gateway.
-- A `ConfigMap` (`gateway-defaults-<slug>`) that injects the stack's `nodeSelector` into the
-  Istio Gateway pod via the `istio` GatewayClass defaults mechanism.
+- A `ConfigMap` (`gateway-defaults-<slug>`) that injects a hard `nodeAffinity` (built from the
+  stack's `nodeSelector` config) into the Istio Gateway pod via the `istio` GatewayClass
+  defaults mechanism.
 
 ---
 
@@ -265,8 +266,9 @@ chart from `https://llm-d-incubation.github.io/llm-d-modelservice/` at version
 Values are merged from two sources:
 1. `deployments/models/<category>/<modelName>/ms-<slug>/values.yaml` — model-specific
    settings (model URI, container images, GPU resources, inference server args).
-2. Programmatic values in `modelservice/deploy.go` — `nodeSelector` and, when the stack sets
-   `gpuToleration`, a matching toleration applied to both decode and prefill pods. The
+2. Programmatic values in `modelservice/deploy.go` — a hard `nodeAffinity` (built from the
+   stack's `nodeSelector` config) and, when the stack sets `gpuToleration`, a matching
+   toleration applied to both decode and prefill pods. The
    toleration's key/value/effect are read from stack config, not hardcoded — they must match
    whatever taint is actually applied to the GPU node.
 

--- a/pkg/iac/monitoring/internal/config/config.go
+++ b/pkg/iac/monitoring/internal/config/config.go
@@ -43,7 +43,6 @@ type S3Config struct {
 type Config struct {
 	Namespace     string
 	CloudProvider string
-	NodeSelector  string
 	Kubeconfig    string
 	Components    map[string]bool
 	S3            S3Config
@@ -88,7 +87,6 @@ func Load(ctx *pulumi.Context, projectDir string) Config {
 	return Config{
 		Namespace:     cfg.Require("namespace"),
 		CloudProvider: cfg.Require("cloudProvider"),
-		NodeSelector:  cfg.Get("nodeSelector"),
 		Kubeconfig:    cfg.Get("kubeconfig"),
 		Components:    loadComponents(cfg),
 		S3: S3Config{

--- a/pkg/iac/serving/internal/components/llmd-infra/deploy.go
+++ b/pkg/iac/serving/internal/components/llmd-infra/deploy.go
@@ -119,8 +119,12 @@ func Deploy(ctx *pulumi.Context, model appConfig.Model, lldChartPath string, opt
 spec:
   template:
     spec:
-      nodeSelector:
-` + renderNodeSelectorYaml(model.NodeSelector)),
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+` + renderNodeAffinityYaml(model.NodeSelector)),
 		},
 	}, cmOpts...)
 	if err != nil {
@@ -130,7 +134,10 @@ spec:
 	return release, nil
 }
 
-func renderNodeSelectorYaml(selector map[string]string) string {
+// renderNodeAffinityYaml renders selector as a sorted list of matchExpressions lines, one
+// {key, In, [value]} entry per key, to be embedded under a requiredDuringSchedulingIgnoredDuringExecution
+// nodeSelectorTerms/matchExpressions block. Sorted for a stable, diff-friendly rendering.
+func renderNodeAffinityYaml(selector map[string]string) string {
 	keys := make([]string, 0, len(selector))
 	for k := range selector {
 		keys = append(keys, k)
@@ -139,7 +146,7 @@ func renderNodeSelectorYaml(selector map[string]string) string {
 
 	lines := make([]string, 0, len(keys))
 	for _, key := range keys {
-		lines = append(lines, "        "+key+": "+selector[key])
+		lines = append(lines, fmt.Sprintf(`              - {key: %s, operator: In, values: [%q]}`, key, selector[key]))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/pkg/iac/serving/internal/components/modelservice/deploy.go
+++ b/pkg/iac/serving/internal/components/modelservice/deploy.go
@@ -38,7 +38,7 @@ func Deploy(
 	}
 
 	podConfig := pulumi.Map{
-		"nodeSelector": model.NodeSelectorMap(),
+		"affinity": model.NodeAffinityMap(),
 	}
 
 	if t := model.GPUToleration; t != nil {

--- a/pkg/iac/serving/internal/config/naming.go
+++ b/pkg/iac/serving/internal/config/naming.go
@@ -1,10 +1,33 @@
 package config
 
 import (
+	"sort"
 	"strings"
 
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+// nodeAffinityMatchExpressions builds a sorted-by-key list of {key, In, [value]}
+// matchExpressions from a nodeSelector-shaped map, so Pulumi diffs stay stable
+// regardless of Go's randomized map iteration order.
+func nodeAffinityMatchExpressions(selector map[string]string) []map[string]interface{} {
+	keys := make([]string, 0, len(selector))
+	for k := range selector {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	exprs := make([]map[string]interface{}, 0, len(keys))
+	for _, k := range keys {
+		exprs = append(exprs, map[string]interface{}{
+			"key":      k,
+			"operator": "In",
+			"values":   []string{selector[k]},
+		})
+	}
+	return exprs
+}
 
 func (m *Model) ReleasePostFix() string {
 	if m.ReleaseName == "" {
@@ -68,6 +91,62 @@ func (m Model) NodeSelectorStringMap() pulumi.StringMap {
 		out[key] = pulumi.String(value)
 	}
 	return out
+}
+
+// NodeAffinityMap builds a hard (required) nodeAffinity as a raw pulumi.Map, for chart values
+// that accept an arbitrary pod-spec passthrough (llm-d-modelservice's extraConfig).
+// Renders to the same requiredDuringSchedulingIgnoredDuringExecution shape used everywhere
+// else in this design. Returns an empty map when NodeSelector is empty, matching
+// NodeSelectorMap's behavior of contributing nothing to the pod spec.
+func (m Model) NodeAffinityMap() pulumi.Map {
+	if len(m.NodeSelector) == 0 {
+		return pulumi.Map{}
+	}
+	return pulumi.Map{
+		"nodeAffinity": pulumi.Map{
+			"requiredDuringSchedulingIgnoredDuringExecution": pulumi.Map{
+				"nodeSelectorTerms": pulumi.Array{
+					pulumi.Map{
+						"matchExpressions": pulumi.Any(nodeAffinityMatchExpressions(m.NodeSelector)),
+					},
+				},
+			},
+		},
+	}
+}
+
+// NodeAffinityArgs builds the same hard (required) nodeAffinity as *corev1.AffinityArgs, for
+// components using typed corev1.PodSpecArgs directly instead of raw Helm values.
+func (m Model) NodeAffinityArgs() *corev1.AffinityArgs {
+	if len(m.NodeSelector) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m.NodeSelector))
+	for k := range m.NodeSelector {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	exprs := make(corev1.NodeSelectorRequirementArray, 0, len(keys))
+	for _, k := range keys {
+		exprs = append(exprs, &corev1.NodeSelectorRequirementArgs{
+			Key:      pulumi.String(k),
+			Operator: pulumi.String("In"),
+			Values:   pulumi.StringArray{pulumi.String(m.NodeSelector[k])},
+		})
+	}
+
+	return &corev1.AffinityArgs{
+		NodeAffinity: &corev1.NodeAffinityArgs{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelectorArgs{
+				NodeSelectorTerms: corev1.NodeSelectorTermArray{
+					&corev1.NodeSelectorTermArgs{
+						MatchExpressions: exprs,
+					},
+				},
+			},
+		},
+	}
 }
 
 func (m Model) Category() string {

--- a/pkg/iac/serving/internal/platform/model_storage.go
+++ b/pkg/iac/serving/internal/platform/model_storage.go
@@ -149,7 +149,7 @@ func CreateModelStorage(ctx *pulumi.Context, model appConfig.Model, llmdNamespac
 					// the PVC is provisioned in the correct zone. Zonal PDs are zone-locked:
 					// if the pull job runs in a different zone than the GPU node, the model
 					// service pod cannot be scheduled because it cannot access the PV.
-					NodeSelector: model.NodeSelectorStringMap(),
+					Affinity: model.NodeAffinityArgs(),
 					// The pull job must land on the same node as the model service pod so the
 					// hostpath PV is accessible. If the GPU node carries a taint, tolerate it.
 					Tolerations: buildTolerations(model),

--- a/pkg/iac/shaide/internal/components/controlpanel/deploy.go
+++ b/pkg/iac/shaide/internal/components/controlpanel/deploy.go
@@ -41,7 +41,10 @@ func Deploy(ctx *pulumi.Context, deps *runtime.DeploymentContext, cfg appconfig.
 					Labels: deps.MetaLabels(name, "console"),
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: cfg.NodeSelectorFor(cfg.NodeSelectorControlPanel),
+					Affinity: &corev1.AffinityArgs{
+						NodeAffinity:    cfg.NodeAffinityFor(cfg.NodeSelectorControlPanel),
+						PodAntiAffinity: deps.PodAntiAffinityFor(name),
+					},
 					ImagePullSecrets: corev1.LocalObjectReferenceArray{
 						&corev1.LocalObjectReferenceArgs{
 							Name: pulumi.String(deps.RegistrySecretName),

--- a/pkg/iac/shaide/internal/components/qdrant/deploy.go
+++ b/pkg/iac/shaide/internal/components/qdrant/deploy.go
@@ -48,7 +48,10 @@ func Deploy(ctx *pulumi.Context, deps *runtime.DeploymentContext, cfg appconfig.
 					Labels: deps.MetaLabels(name, "vector-database"),
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: cfg.NodeSelectorFor(cfg.NodeSelectorQdrant),
+					Affinity: &corev1.AffinityArgs{
+						NodeAffinity:    cfg.NodeAffinityFor(cfg.NodeSelectorQdrant),
+						PodAntiAffinity: deps.PodAntiAffinityFor(name),
+					},
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:            pulumi.String(name),

--- a/pkg/iac/shaide/internal/components/rustfs/deploy.go
+++ b/pkg/iac/shaide/internal/components/rustfs/deploy.go
@@ -143,7 +143,10 @@ func Deploy(ctx *pulumi.Context, deps *runtime.DeploymentContext, cfg appconfig.
 					Labels: deps.MetaLabels(name, "object-storage"),
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: cfg.NodeSelectorFor(cfg.NodeSelectorRustfs),
+					Affinity: &corev1.AffinityArgs{
+						NodeAffinity:    cfg.NodeAffinityFor(cfg.NodeSelectorRustfs),
+						PodAntiAffinity: deps.PodAntiAffinityFor(name),
+					},
 					SecurityContext: &corev1.PodSecurityContextArgs{
 						RunAsUser:  pulumi.Int(rustfsUID),
 						RunAsGroup: pulumi.Int(rustfsUID),

--- a/pkg/iac/shaide/internal/components/shaide/deploy.go
+++ b/pkg/iac/shaide/internal/components/shaide/deploy.go
@@ -64,7 +64,10 @@ func Deploy(ctx *pulumi.Context, deps *runtime.DeploymentContext, cfg appconfig.
 				},
 				Spec: &corev1.PodSpecArgs{
 					ServiceAccountName: pulumi.String(cfg.ServiceAccountName),
-					NodeSelector:       cfg.NodeSelectorFor(cfg.NodeSelectorShaide),
+					Affinity: &corev1.AffinityArgs{
+						NodeAffinity:    cfg.NodeAffinityFor(cfg.NodeSelectorShaide),
+						PodAntiAffinity: deps.PodAntiAffinityFor("shaide-server"),
+					},
 					SecurityContext: &corev1.PodSecurityContextArgs{
 						FsGroup: pulumi.Int(1000),
 					},

--- a/pkg/iac/shaide/internal/components/webapp/deploy.go
+++ b/pkg/iac/shaide/internal/components/webapp/deploy.go
@@ -39,7 +39,10 @@ func Deploy(ctx *pulumi.Context, deps *runtime.DeploymentContext, cfg appconfig.
 					Labels: deps.MetaLabels(name, "webapp"),
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: cfg.NodeSelectorFor(cfg.NodeSelectorWebApp),
+					Affinity: &corev1.AffinityArgs{
+						NodeAffinity:    cfg.NodeAffinityFor(cfg.NodeSelectorWebApp),
+						PodAntiAffinity: deps.PodAntiAffinityFor(name),
+					},
 					ImagePullSecrets: corev1.LocalObjectReferenceArray{
 						&corev1.LocalObjectReferenceArgs{
 							Name: pulumi.String(deps.RegistrySecretName),

--- a/pkg/iac/shaide/internal/config/config.go
+++ b/pkg/iac/shaide/internal/config/config.go
@@ -1,14 +1,19 @@
 package appconfig
 
 import (
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiconfig "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
-// NodeSelectorFor builds a nodeSelector map for a component.
+// NodeAffinityFor builds a soft (preferred) nodeAffinity for a component.
 // override takes precedence over the global NodeSelector.
-// Returns nil when both are empty (no scheduling constraint).
-func (c Config) NodeSelectorFor(override string) pulumi.StringMap {
+// Returns nil when both are empty (no scheduling preference) — same short-circuit as the
+// nodeSelector this replaces. Soft, not hard: the component should prefer a node carrying
+// NodeSelectorKey=val, but must still be able to run elsewhere if none is available.
+// Returns just the NodeAffinity sub-block (not the full AffinityArgs wrapper) so callers can
+// compose it alongside PodAntiAffinityFor in a single Affinity value.
+func (c Config) NodeAffinityFor(override string) *corev1.NodeAffinityArgs {
 	val := override
 	if val == "" {
 		val = c.NodeSelector
@@ -16,7 +21,22 @@ func (c Config) NodeSelectorFor(override string) pulumi.StringMap {
 	if val == "" {
 		return nil
 	}
-	return pulumi.StringMap{c.NodeSelectorKey: pulumi.String(val)}
+	return &corev1.NodeAffinityArgs{
+		PreferredDuringSchedulingIgnoredDuringExecution: corev1.PreferredSchedulingTermArray{
+			&corev1.PreferredSchedulingTermArgs{
+				Weight: pulumi.Int(100),
+				Preference: &corev1.NodeSelectorTermArgs{
+					MatchExpressions: corev1.NodeSelectorRequirementArray{
+						&corev1.NodeSelectorRequirementArgs{
+							Key:      pulumi.String(c.NodeSelectorKey),
+							Operator: pulumi.String("In"),
+							Values:   pulumi.StringArray{pulumi.String(val)},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 type ServiceNames struct {

--- a/pkg/iac/shaide/internal/runtime/context.go
+++ b/pkg/iac/shaide/internal/runtime/context.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+import (
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
 
 // DeploymentContext carries shared Pulumi options for all app-shaide components.
 type DeploymentContext struct {
@@ -14,8 +18,8 @@ type DeploymentContext struct {
 	// Defaults to an empty DependsOn (no-op) for clouds with dynamic provisioning.
 	StorageDeps        pulumi.ResourceOption
 	RegistrySecretName string
-	Labels     func(string) pulumi.StringMap
-	MetaLabels func(name, component string) pulumi.StringMap
+	Labels             func(string) pulumi.StringMap
+	MetaLabels         func(name, component string) pulumi.StringMap
 }
 
 // NewDeploymentContext constructs deployment wiring shared across all components.
@@ -49,6 +53,26 @@ func NewDeploymentContext(
 				"app.kubernetes.io/managed-by": pulumi.String("pulumi"),
 				"axem.dev/platform":            pulumi.String("ai-platform"),
 			}
+		},
+	}
+}
+
+// PodAntiAffinityFor builds a soft (preferred) podAntiAffinity spreading a component's own
+// replicas across nodes, once there's more than one — keyed on the same
+// app.kubernetes.io/name label the component's own Selector already uses, so it only ever
+// avoids co-locating with its own pods, never another component's.
+func (deps *DeploymentContext) PodAntiAffinityFor(name string) *corev1.PodAntiAffinityArgs {
+	return &corev1.PodAntiAffinityArgs{
+		PreferredDuringSchedulingIgnoredDuringExecution: corev1.WeightedPodAffinityTermArray{
+			&corev1.WeightedPodAffinityTermArgs{
+				Weight: pulumi.Int(100),
+				PodAffinityTerm: &corev1.PodAffinityTermArgs{
+					LabelSelector: &metav1.LabelSelectorArgs{
+						MatchLabels: deps.Labels(name),
+					},
+					TopologyKey: pulumi.String("kubernetes.io/hostname"),
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Type of change
- [x] New feature

## Related issue

Closes: 
- [SHD-878](https://axem.atlassian.net/browse/SHD-878)
- [SHD-946](https://axem.atlassian.net/browse/SHD-946)

## Description

Replaces the remaining `nodeSelector` scheduling in `app_serving`, `app_shaide`, and `app_mcp` with Kubernetes `nodeAffinity`.

This aligns the application layer on one scheduling mechanism for the two-label node design:

- `axem.dev/workload-<class>` for workload class placement
- `gpu-type` for GPU model placement

The behavior differs by app where needed:

- `app_shaide` now uses soft `preferredDuringSchedulingIgnoredDuringExecution` node affinity, so its components prefer the configured node label but can still schedule elsewhere if the preferred pool is unavailable.
- `app_shaide` components also get soft pod anti-affinity scoped to their own `app.kubernetes.io/name`, spreading replicas of the same component across hostnames when replicas are increased.
- `app_serving` now uses hard `requiredDuringSchedulingIgnoredDuringExecution` node affinity for modelservice pods, ORAS model pull Jobs, and the Istio Gateway defaults ConfigMap.
- `app_mcp` now uses hard node affinity for datasource deployments.
- `monitoring` no longer loads the unused `nodeSelector` config field.

Configuration updates included in this commit:

- `app_shaide/deployments/Pulumi.aks-kalmannemeth-westeurope.yaml` now targets `axem.dev/workload-cpu: "true"` as a soft preference.

Documentation updates included in this branch:

- `docs/architecture/application-layer.md` now describes `app_shaide` scheduling as soft node affinity plus same-component pod anti-affinity.
- `docs/architecture/model-deployment-flow.md` now describes `app_serving` pod scheduling as hard node affinity for the Gateway defaults and ModelService chart values.

GCP and on-prem stack config migration is intentionally left for a separate pass.

## Validation

- [x] Changed Go files were formatted with `gofmt`.
- [x] `git diff --check` passed for the commit range.

Additional validation details:

- `gofmt -l` returned no files for the changed Go files.
- `git diff --check fb3e7208040da70f57818290052847123d6ac655..764feb92d53cde08aac11a2b270eba23d17226c5` produced no output.

## Deployment and operational impact

This changes rendered pod specs from `nodeSelector` to `affinity.nodeAffinity`.

Expected rollout impact:

- `app_shaide` pods are less strict than before: they prefer the configured node label but are not blocked if no matching node is available.
- `app_serving` model pods, ORAS pull Jobs, and Istio gateway deployments remain strictly pinned to matching nodes.
- `app_mcp` datasource pods remain strictly pinned when a node selector value is configured.
- Existing config key names remain in use (`nodeSelectorKey`, `nodeSelector`, and per-component/per-datasource overrides), but they now render node affinity instead of the pod `nodeSelector` field.

Before deployment, verify target clusters have the expected labels on the intended nodes or node pools:

```sh
kubectl get nodes --show-labels
```

For the updated AKS `app_shaide` stack, nodes intended for Shaide should carry:

```text
axem.dev/workload-cpu=true
```

Rollback impact: reverting this change restores `nodeSelector` rendering and removes the new soft pod anti-affinity behavior for `app_shaide`.

## Documentation

Updated:

- `docs/architecture/application-layer.md`
- `docs/architecture/model-deployment-flow.md`

The docs now describe pod-level scheduling in terms of rendered `nodeAffinity` instead of direct `nodeSelector` fields where this branch changed the behavior.

## Checklist

- [x] I added or updated tests for changed behavior, or explained why tests are not needed.
- [x] I updated documentation for deployment, configuration, topology, or operational changes.
- [x] My commits follow the Conventional Commits specification.
- [ ] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.

Tests were not added because this change rewires Pulumi-rendered scheduling fields from `nodeSelector` to equivalent `nodeAffinity` structures without adding new runtime code paths.

Documentation was updated in the follow-up commit `docs(architecture): describe nodeAffinity instead of nodeSelector in pod-level docs`.

Commit messages follow Conventional Commits:

- `feat: replace nodeSelector with nodeAffinity across app_serving, app_shaide, app_mcp`
- `docs(architecture): describe nodeAffinity instead of nodeSelector in pod-level docs`

The commits do not include `Signed-off-by` trailers.

No Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets are included.

## Screenshots

Not applicable.

## Additional information

The local diff for this branch contains the app scheduling changes, the active AKS `app_shaide` stack update, and the architecture docs update. The implementation commit message also notes broader node-pool label work and AKS `app_serving` stack config updates; those files are not present in this local branch range, so they are not listed as changed files in this PR body.


[SHD-878]: https://axem.atlassian.net/browse/SHD-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SHD-946]: https://axem.atlassian.net/browse/SHD-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ