### PR TITLE
feat(control-panel): add KNOWLEDGE_CENTER_ENABLED env var

### DIFF
--- a/app_shaide/README.md
+++ b/app_shaide/README.md
@@ -85,7 +85,9 @@ Loads and types all Pulumi stack config into a single `Config` struct.
   `cloudprovider.Provider`.
 - `controlpanel/deploy.go`: Deploys the control panel as a Deployment (single replica,
   no persistence) with a `ClusterIP` Service on port `3000`. Receives `SESSION_SECRET`
-  from the shared `shaide-secrets` Secret. It has no direct knowledge of installed
+  from the shared `shaide-secrets` Secret, and `KNOWLEDGE_CENTER_ENABLED`
+  (`"true"`/`"false"`, from `knowledgeCenterEnabled`; default: false) indicating whether
+  the Knowledge Center feature is present. It has no direct knowledge of installed
   models — it consumes shaide-server's own model API. See
   [Installed Model Discovery](#installed-model-discovery) below.
 - `webapp/deploy.go`: Deploys the end-user facing web application as a Deployment

--- a/app_shaide/deployments/Pulumi.TEMPLATE.yaml
+++ b/app_shaide/deployments/Pulumi.TEMPLATE.yaml
@@ -103,6 +103,9 @@
 #   rustfsConsoleEnabled
 #                     — boolean; exposes the RustFS console on port 9001 in addition to the
 #                        S3 API on port 9000; default: false
+#   knowledgeCenterEnabled
+#                     — boolean; presence of the Knowledge Center feature; injected into
+#                        control-panel as the KNOWLEDGE_CENTER_ENABLED env var; default: false
 #
 # To create a new stack:
 #   cd app_shaide/deployments
@@ -168,6 +171,7 @@ config:
   # app-shaide:rustSpantrace: "0"
   # app-shaide:trial: "FALSE"
   # app-shaide:rustfsConsoleEnabled: false
+  # app-shaide:knowledgeCenterEnabled: false
   app-shaide:rustfsNotifyWebhookEnableShaide: "on"
   app-shaide:rustfsNotifyWebhookEndpointShaide: "http://shaide-server/v1/object-storage/event"
   app-shaide:rustfsNotifyWebhookQueueDirShaide: "/data/deploy/logs/notify"

--- a/pkg/iac/shaide/internal/components/controlpanel/deploy.go
+++ b/pkg/iac/shaide/internal/components/controlpanel/deploy.go
@@ -4,6 +4,8 @@
 package controlpanel
 
 import (
+	"strconv"
+
 	appconfig "github.com/axem-solutions/ai_platform/pkg/iac/shaide/internal/config"
 	"github.com/axem-solutions/ai_platform/pkg/iac/shaide/internal/runtime"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
@@ -72,6 +74,10 @@ func Deploy(ctx *pulumi.Context, deps *runtime.DeploymentContext, cfg appconfig.
 											Key:  pulumi.String("SESSION_SECRET"),
 										},
 									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("KNOWLEDGE_CENTER_ENABLED"),
+									Value: pulumi.String(strconv.FormatBool(cfg.KnowledgeCenterEnabled)),
 								},
 							},
 							Ports: corev1.ContainerPortArray{

--- a/pkg/iac/shaide/internal/config/config.go
+++ b/pkg/iac/shaide/internal/config/config.go
@@ -115,6 +115,7 @@ type Config struct {
 	ShaidePVSize             string // optional — shaide-server PV/PVC size (default: 5Gi)
 	RustfsPVSize             string // optional — rustfs PV/PVC size (default: 5Gi)
 	QdrantPVSize             string // optional — qdrant PV/PVC size (default: 5Gi)
+	KnowledgeCenterEnabled   bool   // optional — presence of the Knowledge Center feature; injected into control-panel as KNOWLEDGE_CENTER_ENABLED; default: false
 
 	LBAnnotations             map[string]string
 	ServiceAccountAnnotations map[string]string
@@ -162,6 +163,7 @@ func Load(ctx *pulumi.Context) Config {
 		ShaidePVSize:              getWithDefault(cfg, "shaidePVSize", "5Gi"),
 		RustfsPVSize:              getWithDefault(cfg, "rustfsPVSize", "5Gi"),
 		QdrantPVSize:              getWithDefault(cfg, "qdrantPVSize", "5Gi"),
+		KnowledgeCenterEnabled:    cfg.GetBool("knowledgeCenterEnabled"),
 		LBAnnotations:             lbAnnotations,
 		ServiceAccountAnnotations: saAnnotations,
 		ServiceAccountName:        cfg.Require(("shaideServiceAccountName")),


### PR DESCRIPTION
## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring or maintenance
- [x] Documentation update

## Related issue

Closes [SHD-952](https://axem.atlassian.net/browse/SHD-952)

## Description

Adds a configurable Knowledge Center presence flag for the control panel deployment.

- Adds optional `knowledgeCenterEnabled` to the app SHAIDE Pulumi config, defaulting to `false` when unset.
- Injects the value into the control panel container as `KNOWLEDGE_CENTER_ENABLED` with `"true"`/`"false"` string values.
- Documents the new stack config key in `app_shaide/deployments/Pulumi.TEMPLATE.yaml`.
- Updates the app SHAIDE README control panel component notes to describe the new environment variable.

Affected area: `app_shaide` Pulumi infrastructure and the generated control panel Kubernetes Deployment environment.

## Validation

- [x] Changed Go files were formatted with `gofmt`.
- [ ] `go test ./...` passed in every affected Go module.

Additional validation details:

- Not run locally while preparing this PR description.
- Change is limited to Pulumi config loading, Deployment env var injection, and documentation/template updates.

## Deployment and operational impact

New optional Pulumi config:

- `app-shaide:knowledgeCenterEnabled`: boolean, default `false`.

When set, the control panel Deployment receives `KNOWLEDGE_CENTER_ENABLED` as `"true"` or `"false"`. Existing stacks remain compatible because the unset value defaults to `false`. No migrations or rollout ordering are required.

Rollback: revert this change or unset `app-shaide:knowledgeCenterEnabled`; the control panel will receive the default disabled value.

## Documentation

Updated:

- `app_shaide/deployments/Pulumi.TEMPLATE.yaml`
- `app_shaide/README.md`

## Checklist

- [x] I added or updated tests for changed behavior, or explained why tests are not needed.
- [x] I updated documentation for deployment, configuration, topology, or operational changes.
- [x] My commits follow the Conventional Commits specification.
- [x] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.

## Screenshots

N/A

## Additional information

The control panel still has no direct knowledge of installed models; this flag only communicates whether the Knowledge Center feature is present.


[SHD-952]: https://axem.atlassian.net/browse/SHD-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ