### PR TITLE
fix(installer): report source registry pull failures against the right registry

### DIFF
--- a/installer/internal/oras/client/client.go
+++ b/installer/internal/oras/client/client.go
@@ -99,6 +99,12 @@ func authCredential(credential Credential) auth.Credential {
 	}
 }
 
+// Registry is the push target host[:port]. Callers compare a failing host
+// against it to tell a Harbor rejection from an upstream registry's.
+func (c *Client) Registry() string {
+	return c.registry
+}
+
 func (c *Client) NewTargetRepository(project string, repositoryName string, opts repository.ChunkedUploadOptions) (*repository.Repository, error) {
 	ref := fmt.Sprintf("%s/%s/%s", c.registry, project, repositoryName)
 

--- a/installer/internal/oras/errdef/errors.go
+++ b/installer/internal/oras/errdef/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/axem-solutions/ai_platform/installer/internal/httpapi"
 	"oras.land/oras-go/v2/registry/remote/errcode"
@@ -26,11 +27,37 @@ var (
 	ErrArtifactBuildFailure   = errors.New("artifact build failure")
 )
 
+// Scope says which side of a mirror failed. Every upload both pulls from an
+// upstream registry and pushes to Harbor over the same oras client, so without
+// this an auth failure on either leg looks identical — and a source-side 401
+// was reported to the operator as a Harbor credential problem, offering a
+// Harbor password prompt that could never fix it.
+type Scope string
+
+const (
+	// ScopeTarget is the Harbor registry the installer pushes into.
+	ScopeTarget Scope = "target"
+
+	// ScopeSource is the upstream registry an image is pulled from.
+	ScopeSource Scope = "source"
+
+	// ScopeLocal is a failure with no registry behind it, such as a bad
+	// archive or stale upload state.
+	ScopeLocal Scope = "local"
+)
+
 type Error struct {
-	Kind   ErrorKind
-	Op     string
+	Kind ErrorKind
+	Op   string
+	// Target is the artifact being uploaded, not a registry.
 	Target string
-	Err    error
+
+	// Registry is the host that returned the failure, empty when the failure
+	// did not come from a registry request.
+	Registry string
+	Scope    Scope
+
+	Err error
 }
 
 func (e *Error) Error() string {
@@ -45,7 +72,57 @@ func (e *Error) Unwrap() error {
 	return e.Err
 }
 
+// RegistryHost reports the host that produced an HTTP failure, or "" when the
+// error did not come from a registry request.
+//
+// Both error types carry the request URL, so the failing registry is recovered
+// from the error itself rather than threaded through every call site. Note the
+// URL can belong to a registry's token service rather than the registry itself
+// (Docker Hub answers challenges from auth.docker.io), so callers matching a
+// host to credentials must treat those as the same registry.
+func RegistryHost(err error) string {
+	var respErr *errcode.ErrorResponse
+	if errors.As(err, &respErr) && respErr.URL != nil {
+		return respErr.URL.Host
+	}
+
+	var statusErr *httpapi.StatusError
+	if errors.As(err, &statusErr) {
+		if parsed, parseErr := url.Parse(statusErr.URL); parseErr == nil {
+			return parsed.Host
+		}
+	}
+
+	return ""
+}
+
+// UserMessage describes a failure against Harbor. Callers holding an *Error
+// should use its UserMessage method instead, which also handles source
+// registries.
 func UserMessage(kind ErrorKind) string {
+	return targetMessage(kind)
+}
+
+// UserMessage describes the failure in terms of the registry that caused it.
+func (e *Error) UserMessage() string {
+	if e.Scope == ScopeSource {
+		return sourceMessage(e.Kind, e.RegistryLabel())
+	}
+
+	return targetMessage(e.Kind)
+}
+
+// RegistryLabel names the failing registry for display, falling back to a
+// generic phrase when the host could not be determined.
+func (e *Error) RegistryLabel() string {
+	if e.Registry == "" {
+		return "the source registry"
+	}
+
+	return e.Registry
+}
+
+func targetMessage(kind ErrorKind) string {
 	switch kind {
 	case httpapi.ErrAuth:
 		return "Harbor credentials are invalid or do not have push access"
@@ -65,6 +142,26 @@ func UserMessage(kind ErrorKind) string {
 		return "Harbor registry does not support this model upload"
 	default:
 		return "artifact upload failed"
+	}
+}
+
+// sourceMessage describes a failure pulling the image, before Harbor is
+// involved at all. Harbor credentials are never the cause here.
+func sourceMessage(kind ErrorKind, registry string) string {
+	switch kind {
+	case httpapi.ErrAuth:
+		// The installer mirrors public images only, so a refused pull means
+		// the image is not published publicly rather than that a credential
+		// is wrong.
+		return fmt.Sprintf("%s refused the pull: the image is not publicly readable", registry)
+	case httpapi.ErrNotFound:
+		return fmt.Sprintf("%s has no such repository or tag", registry)
+	case httpapi.ErrRateLimited:
+		return fmt.Sprintf("%s rate limit was reached", registry)
+	case httpapi.ErrNetwork:
+		return fmt.Sprintf("%s is unreachable", registry)
+	default:
+		return fmt.Sprintf("the image could not be read from %s", registry)
 	}
 }
 

--- a/installer/internal/oras/errdef/errors_test.go
+++ b/installer/internal/oras/errdef/errors_test.go
@@ -1,0 +1,107 @@
+package errdef
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/axem-solutions/ai_platform/installer/internal/httpapi"
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+func TestRegistryHost(t *testing.T) {
+	tokenURL, err := url.Parse("https://ghcr.io/token?scope=repository%3Aaxem-solutions%2Fshaide_control_panel%3Apull")
+	if err != nil {
+		t.Fatalf("parse token url: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "registry error response",
+			err:  &errcode.ErrorResponse{Method: "GET", URL: tokenURL, StatusCode: 401},
+			want: "ghcr.io",
+		},
+		{
+			// The uploader never sees a bare registry error: oras wraps it in
+			// the manifest request that triggered the token fetch.
+			name: "wrapped registry error response",
+			err: fmt.Errorf("resolve remote image ref %q: %w", "ghcr",
+				fmt.Errorf("HEAD %q: %w", "https://ghcr.io/v2/x/manifests/dev",
+					&errcode.ErrorResponse{Method: "GET", URL: tokenURL, StatusCode: 401})),
+			want: "ghcr.io",
+		},
+		{
+			name: "http status error",
+			err:  &httpapi.StatusError{StatusCode: 401, Method: "GET", URL: "http://127.0.0.1:5000/v2/shaide/x/manifests/dev"},
+			want: "127.0.0.1:5000",
+		},
+		{
+			name: "non-http error",
+			err:  fmt.Errorf("open docker image archive: no such file"),
+			want: "",
+		},
+		{
+			name: "error response without url",
+			err:  &errcode.ErrorResponse{StatusCode: 401},
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RegistryHost(test.err); got != test.want {
+				t.Errorf("RegistryHost() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// A source-side rejection must not be reported as a Harbor problem: that
+// wording sent operators to check Harbor credentials for a failure that
+// happened before Harbor was contacted.
+func TestErrorUserMessageNamesFailingRegistry(t *testing.T) {
+	sourceErr := &Error{
+		Kind:     httpapi.ErrAuth,
+		Op:       "prepare image artifact",
+		Target:   "axem-solutions/shaide_control_panel",
+		Registry: "ghcr.io",
+		Scope:    ScopeSource,
+	}
+
+	message := sourceErr.UserMessage()
+	if !strings.Contains(message, "ghcr.io") {
+		t.Errorf("source message %q does not name the failing registry", message)
+	}
+	if strings.Contains(message, "Harbor") {
+		t.Errorf("source message %q blames Harbor for an upstream failure", message)
+	}
+
+	targetErr := &Error{Kind: httpapi.ErrAuth, Scope: ScopeTarget, Registry: "127.0.0.1:5000"}
+	if got, want := targetErr.UserMessage(), UserMessage(httpapi.ErrAuth); got != want {
+		t.Errorf("target message = %q, want the Harbor message %q", got, want)
+	}
+}
+
+func TestErrorRegistryLabelFallsBack(t *testing.T) {
+	unknown := &Error{Kind: httpapi.ErrAuth, Scope: ScopeSource}
+	if got := unknown.RegistryLabel(); got != "the source registry" {
+		t.Errorf("RegistryLabel() = %q, want a generic fallback", got)
+	}
+	if strings.Contains(unknown.UserMessage(), "Harbor") {
+		t.Errorf("unattributed source failure still blames Harbor: %q", unknown.UserMessage())
+	}
+}
+
+// Local failures keep the existing wording: they are not registry problems and
+// the operator should not be pointed at any registry.
+func TestLocalScopeKeepsExistingMessages(t *testing.T) {
+	local := &Error{Kind: ErrUploadState, Scope: ScopeLocal}
+	if got, want := local.UserMessage(), UserMessage(ErrUploadState); got != want {
+		t.Errorf("local message = %q, want %q", got, want)
+	}
+}

--- a/installer/internal/oras/uploader/image_upload.go
+++ b/installer/internal/oras/uploader/image_upload.go
@@ -18,11 +18,11 @@ func (u *Uploader) UploadImages(ctx context.Context, imageDir string, images []c
 
 		artifact, err := u.prepareImageArtifact(ctx, imageDir, image)
 		if err != nil {
-			return uploadError("prepare image artifact", image.Name, err)
+			return u.uploadError("prepare image artifact", image.Name, err)
 		}
 
 		if _, err := u.push(ctx, artifact); err != nil {
-			return uploadError("push image artifact", image.Name, err)
+			return u.uploadError("push image artifact", image.Name, err)
 		}
 	}
 

--- a/installer/internal/oras/uploader/model_upload.go
+++ b/installer/internal/oras/uploader/model_upload.go
@@ -27,11 +27,11 @@ func (u *Uploader) UploadModels(ctx context.Context, hubdir string, models []cat
 
 		artifact, err := u.prepareModelArtifact(ctx, hubdir, model)
 		if err != nil {
-			return uploadError("prepare model artifact", model.HarborName, err)
+			return u.uploadError("prepare model artifact", model.HarborName, err)
 		}
 
 		if _, err := u.push(ctx, artifact); err != nil {
-			return uploadError("push model artifact", model.HarborName, err)
+			return u.uploadError("push model artifact", model.HarborName, err)
 		}
 	}
 

--- a/installer/internal/oras/uploader/uploader.go
+++ b/installer/internal/oras/uploader/uploader.go
@@ -244,11 +244,29 @@ func targetRef(project string, name string, tag string) string {
 	return fmt.Sprintf("%s/%s:%s", project, name, tag)
 }
 
-func uploadError(op string, target string, err error) error {
+func (u *Uploader) uploadError(op string, target string, err error) error {
+	registry := errdef.RegistryHost(err)
+
 	return &errdef.Error{
-		Kind:   errdef.ClassifyError(err),
-		Op:     op,
-		Target: target,
-		Err:    err,
+		Kind:     errdef.ClassifyError(err),
+		Op:       op,
+		Target:   target,
+		Registry: registry,
+		Scope:    u.scope(registry),
+		Err:      err,
+	}
+}
+
+// scope attributes a failure to the registry that returned it. Anything that is
+// not the push target is upstream: the uploader pulls from several source
+// registries but only ever pushes to Harbor.
+func (u *Uploader) scope(registry string) errdef.Scope {
+	switch registry {
+	case "":
+		return errdef.ScopeLocal
+	case u.client.Registry():
+		return errdef.ScopeTarget
+	default:
+		return errdef.ScopeSource
 	}
 }

--- a/installer/internal/workflow/stages/artifact/recovery.go
+++ b/installer/internal/workflow/stages/artifact/recovery.go
@@ -134,11 +134,21 @@ func recoverArtifactUpload(rt *core.Runtime, runErr error) (core.RecoveryAction,
 		return core.RecoveryFail, nil
 	}
 
-	cause := oras.UserMessage(orasErr.Kind)
-	errMsg := fmt.Sprintf("Upload failed for %s.\n %s", orasErr.Target, cause)
+	errMsg := fmt.Sprintf("Upload failed for %s.\n %s", orasErr.Target, orasErr.UserMessage())
 
 	switch orasErr.Kind {
 	case httpapi.ErrAuth:
+		// Every image the installer mirrors is expected to be publicly
+		// pullable, so a source registry refusing the pull is an upstream
+		// visibility problem. There is no credential to enter here, and the
+		// Harbor prompt would only send the operator after the wrong one.
+		if orasErr.Scope == oras.ScopeSource {
+			return recoverRetryableModelUpload(rt, fmt.Sprintf(
+				"%s\n Make %s publicly readable, then retry.",
+				errMsg,
+				orasErr.Target,
+			))
+		}
 		return recoverModelUploadAuth(rt, errMsg)
 	case httpapi.ErrNetwork, httpapi.ErrRateLimited:
 		return recoverRetryableModelUpload(rt, errMsg)

--- a/installer/internal/workflow/stages/artifact/recovery_test.go
+++ b/installer/internal/workflow/stages/artifact/recovery_test.go
@@ -1,0 +1,169 @@
+package artifact
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/axem-solutions/ai_platform/installer/internal/httpapi"
+	oras "github.com/axem-solutions/ai_platform/installer/internal/oras/errdef"
+	"github.com/axem-solutions/ai_platform/installer/internal/workflow/core"
+)
+
+// fakeReporter answers prompts from a script and records what it was asked, so
+// a test can assert which credentials the operator was sent to fix.
+type fakeReporter struct {
+	selectAnswer string
+	inputAnswers []string
+
+	selectTitles  []string
+	selectOptions [][]string
+	inputTitles   []string
+}
+
+func (r *fakeReporter) Select(title string, _ string, options []string) (string, error) {
+	r.selectTitles = append(r.selectTitles, title)
+	r.selectOptions = append(r.selectOptions, options)
+	return r.selectAnswer, nil
+}
+
+func (r *fakeReporter) MultiSelect(string, []string) ([]string, error) { return nil, nil }
+
+func (r *fakeReporter) ProgressModel(core.ModelProgress) {}
+
+func (r *fakeReporter) Input(title string, _ string, _ string) (string, error) {
+	r.inputTitles = append(r.inputTitles, title)
+	if len(r.inputAnswers) == 0 {
+		return "", fmt.Errorf("unexpected Input(%q)", title)
+	}
+	answer := r.inputAnswers[0]
+	r.inputAnswers = r.inputAnswers[1:]
+	return answer, nil
+}
+
+func newTestRuntime(reporter core.Reporter) *core.Runtime {
+	return &core.Runtime{
+		Reporter:         reporter,
+		GlobalState:      core.NewGlobalState(),
+		ActiveStageState: core.NewActiveStageState(),
+	}
+}
+
+func sourceAuthError(registry string) error {
+	return &oras.Error{
+		Kind:     httpapi.ErrAuth,
+		Op:       "prepare image artifact",
+		Target:   "axem-solutions/shaide_control_panel",
+		Registry: registry,
+		Scope:    oras.ScopeSource,
+	}
+}
+
+// The bug this guards: a 401 from ghcr.io was routed to the Harbor credential
+// prompt, so entering a Harbor password was the only offered fix for a failure
+// Harbor had no part in. The installer mirrors public images only, so there is
+// no credential to enter for a source registry either.
+func TestRecoverArtifactUploadSourceAuthOffersRetryAndAbortOnly(t *testing.T) {
+	reporter := &fakeReporter{selectAnswer: "Retry"}
+	rt := newTestRuntime(reporter)
+
+	action, err := recoverArtifactUpload(rt, sourceAuthError("ghcr.io"))
+	if err != nil {
+		t.Fatalf("recoverArtifactUpload() error = %v", err)
+	}
+	if action != core.RecoveryRetryStep {
+		t.Errorf("action = %v, want RecoveryRetryStep", action)
+	}
+
+	if len(reporter.inputTitles) != 0 {
+		t.Errorf("prompted for credentials on a source-registry failure: %v", reporter.inputTitles)
+	}
+	if rt.Discovery.Auth.Password != "" {
+		t.Errorf("Harbor credentials were overwritten by a source-registry failure")
+	}
+
+	if len(reporter.selectOptions) == 0 {
+		t.Fatal("no prompt was shown")
+	}
+	want := []string{"Retry", "Abort"}
+	got := reporter.selectOptions[0]
+	if len(got) != len(want) {
+		t.Fatalf("options = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("options = %v, want %v", got, want)
+		}
+	}
+}
+
+// The prompt has to say which registry refused and what to do about it,
+// because neither is recoverable from inside the installer.
+func TestRecoverArtifactUploadSourceAuthPromptIsActionable(t *testing.T) {
+	reporter := &fakeReporter{selectAnswer: "Abort"}
+	rt := newTestRuntime(reporter)
+
+	if _, err := recoverArtifactUpload(rt, sourceAuthError("ghcr.io")); err != nil {
+		t.Fatalf("recoverArtifactUpload() error = %v", err)
+	}
+
+	title := reporter.selectTitles[0]
+	for _, want := range []string{"ghcr.io", "axem-solutions/shaide_control_panel", "publicly readable"} {
+		if !strings.Contains(title, want) {
+			t.Errorf("prompt %q does not mention %q", title, want)
+		}
+	}
+	if strings.Contains(title, "Harbor") {
+		t.Errorf("prompt %q blames Harbor for an upstream failure", title)
+	}
+}
+
+// A registry with no special handling must behave the same way: the failure is
+// upstream regardless of which registry it came from.
+func TestRecoverArtifactUploadSourceAuthUniformAcrossRegistries(t *testing.T) {
+	for _, registry := range []string{"docker.io", "auth.docker.io", "nvcr.io", "quay.io", "registry.k8s.io"} {
+		t.Run(registry, func(t *testing.T) {
+			reporter := &fakeReporter{selectAnswer: "Abort"}
+			rt := newTestRuntime(reporter)
+
+			action, err := recoverArtifactUpload(rt, sourceAuthError(registry))
+			if err != nil {
+				t.Fatalf("recoverArtifactUpload() error = %v", err)
+			}
+			if action != core.RecoveryFail {
+				t.Errorf("action = %v, want RecoveryFail", action)
+			}
+			if len(reporter.inputTitles) != 0 {
+				t.Errorf("prompted for credentials: %v", reporter.inputTitles)
+			}
+		})
+	}
+}
+
+// Harbor push failures must keep their existing recovery path.
+func TestRecoverArtifactUploadTargetAuthStillPromptsHarbor(t *testing.T) {
+	reporter := &fakeReporter{
+		selectAnswer: "Enter new credentials",
+		inputAnswers: []string{"admin", "harbor-password"},
+	}
+	rt := newTestRuntime(reporter)
+
+	targetErr := &oras.Error{
+		Kind:     httpapi.ErrAuth,
+		Op:       "push image artifact",
+		Target:   "axem-solutions/shaide_server",
+		Registry: "127.0.0.1:5000",
+		Scope:    oras.ScopeTarget,
+	}
+
+	action, err := recoverArtifactUpload(rt, targetErr)
+	if err != nil {
+		t.Fatalf("recoverArtifactUpload() error = %v", err)
+	}
+	if action != core.RecoveryRetryStep {
+		t.Errorf("action = %v, want RecoveryRetryStep", action)
+	}
+	if rt.Discovery.Auth.Password != "harbor-password" {
+		t.Errorf("Harbor password = %q, want the entered value", rt.Discovery.Auth.Password)
+	}
+}

--- a/installer/internal/workflow/stages/discovery/discovery.go
+++ b/installer/internal/workflow/stages/discovery/discovery.go
@@ -48,9 +48,15 @@ func Stage() core.Stage {
 			// Both paths converge here: the Harbor project selects its storage
 			// behaviour from the configured platform, so one deploy step
 			// serves on-prem and cloud alike.
+			// Only on a fresh install. CheckResources sets Update mode when it
+			// finds a reachable Harbor, and the installer holds no Pulumi state
+			// for a Harbor it did not deploy — so an ungated run would try to
+			// create the Helm release and fail with "cannot re-use a name that
+			// is still in use".
 			{
 				Name:    "deploy Harbor",
 				Run:     stacks.DeployHarbor,
+				When:    InstallMode,
 				Recover: pulumi.RecoverHarbor,
 			},
 			{


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

[SHD-1015](https://axem.atlassian.net/browse/SHD-1015)

## Description

A source registry refusing an image pull was reported to the operator as a Harbor
credential problem, and the only offered recovery was a Harbor username/password
prompt that could not fix it.

The failure happens while resolving the source image, before Harbor is contacted.
In the run that prompted this, `ghcr.io` returned 401 for a package that was not
publicly readable, while Harbor push auth was working: other images in the same
run uploaded successfully seconds earlier.

`errdef.Error` now records which registry returned the failure and whether that
registry was the Harbor push target, an upstream source, or neither. The host is
recovered from the error itself, since both `errcode.ErrorResponse` and
`httpapi.StatusError` already carry the request URL, so no call site between the
HTTP client and the recovery UI needed a new parameter.

Messages are chosen from that scope. A source failure now names the registry that
refused, and the recovery offers only Retry and Abort: every image the installer
mirrors is expected to come from a public repository, so there is no credential
for the operator to enter. Harbor push failures keep their existing message and
credential prompt.

Before:

```
Upload failed for axem-solutions/shaide_control_panel.
 Harbor credentials are invalid or do not have push access
  > Enter new credentials
    Retry
    Abort
```

After:

```
Upload failed for axem-solutions/shaide_control_panel.
 ghcr.io refused the pull: the image is not publicly readable
 Make axem-solutions/shaide_control_panel publicly readable, then retry.
  > Retry
    Abort
```

Affected components: installer artifact stage only. No behaviour change for
Harbor-side failures.

## Validation

- [x] Changed Go files were formatted with `gofmt`.
- [x] `go test ./...` passed in every affected Go module.

Additional validation details:

- `go build ./...`, `go vet ./...` and `go test ./...` pass in the `installer` module.
- New tests cover host extraction from both error types (including the nested
  shape produced by oras: `resolve remote image ref` wrapping `HEAD` wrapping the
  token request), that a source message never blames Harbor, and that target and
  local messages are byte-identical to before.
- The recovery tests drive the real `recoverArtifactUpload` through a fake
  `Reporter` and assert the prompt offers exactly `[Retry, Abort]`, never calls
  `Input`, never touches `rt.Discovery.Auth`, names the registry and image, and
  behaves the same for `docker.io`, `nvcr.io`, `quay.io` and `registry.k8s.io`.
  Harbor push failures still reach the credential prompt.
- The new tests were confirmed to fail against the previous routing.

## Deployment and operational impact

None. No configuration, CRD, or rollout changes. `GHCR_USERNAME`, `GHCR_TOKEN`,
`DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` are still read and still passed to
the oras client; the installer simply never prompts for them.

## Documentation

None needed. No operator-facing configuration or topology changed.

## Checklist

- [x] I added or updated tests for changed behavior, or explained why tests are not needed.
- [ ] I updated documentation for deployment, configuration, topology, or operational changes. (No documented behaviour changed.)
- [x] My commits follow the Conventional Commits specification.
- [x] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.

## Additional information

The `deploy Harbor` gating in `discovery.go` is carried on this branch as a
separate change: `CheckResources` sets Update mode when it finds a reachable
Harbor, and an ungated run tried to create the Helm release and failed with
"cannot re-use a name that is still in use".


[SHD-1015]: https://axem.atlassian.net/browse/SHD-1015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ