### PR TITLE
fix(installer): make large image uploads to Harbor resumable and faster

### DIFF
--- a/installer/internal/oras/client/client.go
+++ b/installer/internal/oras/client/client.go
@@ -3,7 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/axem-solutions/ai_platform/installer/internal/config/catalog"
 	"github.com/axem-solutions/ai_platform/installer/internal/oras/repository"
@@ -20,6 +22,14 @@ const (
 	QuayRegistry        = "quay.io"
 	RegistryK8sRegistry = "registry.k8s.io"
 )
+
+// responseHeaderTimeout bounds the wait for response headers once a request
+// body has been sent. Harbor is reached through a port-forward, and when that
+// tunnel dies mid-transfer the socket stays open with nothing behind it: an
+// unbounded wait turned a dropped connection into a 17-minute stall before the
+// chunk retry could even begin. The clock starts after the body is written, so
+// this does not cap the time spent uploading a chunk.
+const responseHeaderTimeout = 2 * time.Minute
 
 type Client struct {
 	registry string
@@ -49,7 +59,7 @@ func newAuthClient(opts ClientOptions) *auth.Client {
 	credentials := registryCredentials(opts)
 
 	return &auth.Client{
-		Client: retry.DefaultClient,
+		Client: retryClient(),
 		Cache:  auth.NewCache(),
 		// Credential is called by ORAS when a registry request requires authentication.
 		// registry is the request host[:port]. Return EmptyCredential when no matching
@@ -62,6 +72,20 @@ func newAuthClient(opts ClientOptions) *auth.Client {
 			return authCredential(credential), nil
 		},
 	}
+}
+
+// retryClient is oras' retrying client over a transport that will not wait
+// forever for a response.
+func retryClient() *http.Client {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return retry.DefaultClient
+	}
+
+	base := transport.Clone()
+	base.ResponseHeaderTimeout = responseHeaderTimeout
+
+	return &http.Client{Transport: retry.NewTransport(base)}
 }
 
 func registryCredentials(opts ClientOptions) map[string]Credential {

--- a/installer/internal/oras/errdef/classify.go
+++ b/installer/internal/oras/errdef/classify.go
@@ -3,7 +3,10 @@ package errdef
 import (
 	"context"
 	"errors"
+	"io"
+	"net"
 	"net/http"
+	"syscall"
 
 	"github.com/axem-solutions/ai_platform/installer/internal/httpapi"
 	oraserrdef "oras.land/oras-go/v2/errdef"
@@ -52,7 +55,41 @@ func ClassifyError(err error) ErrorKind {
 	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
 		return httpapi.ErrNetwork
 	}
+
+	// A transport-level failure carries no registry response to inspect, so it
+	// reaches here as a bare *url.Error, EOF or a refused dial. Without this it
+	// classified as unknown and the artifact stage treated a dropped
+	// connection as fatal, discarding upload state that could have resumed the
+	// blob. httpapi.ClassifyError has always made this distinction; the oras
+	// path needs it too.
+	if isNetworkError(err) {
+		return httpapi.ErrNetwork
+	}
+
 	return httpapi.ErrUnknown
+}
+
+// isNetworkError reports whether err is a connection that failed or went away
+// rather than a registry that answered.
+func isNetworkError(err error) bool {
+	switch {
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		// A port-forward dying mid-request surfaces as an EOF on the PATCH.
+		return true
+	case errors.Is(err, syscall.ECONNREFUSED),
+		errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, syscall.EPIPE),
+		errors.Is(err, syscall.ETIMEDOUT):
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
 }
 
 func classifyRegistryErrors(registryErrors errcode.Errors) ErrorKind {

--- a/installer/internal/oras/errdef/classify_test.go
+++ b/installer/internal/oras/errdef/classify_test.go
@@ -1,0 +1,154 @@
+package errdef
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"syscall"
+	"testing"
+
+	"github.com/axem-solutions/ai_platform/installer/internal/httpapi"
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+// A dropped connection used to classify as unknown, which the artifact stage
+// treats as fatal: the run aborted instead of offering a retry, discarding
+// upload state that could have resumed the blob.
+func TestClassifyErrorNetworkFailures(t *testing.T) {
+	patchURL := "http://127.0.0.1:5000/v2/services/llm-d/llm-d-cuda/blobs/uploads/7d77f287"
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			// The exact shape from a port-forward dying mid-upload: the PATCH
+			// fails with EOF, and the status check that follows cannot dial.
+			name: "chunk patch eof then refused status check",
+			err: fmt.Errorf("%w; recover failed chunk: %v",
+				fmt.Errorf("upload blob chunk: %w", &url.Error{Op: "Patch", URL: patchURL, Err: io.EOF}),
+				fmt.Errorf("check upload status: %w", &url.Error{
+					Op:  "Get",
+					URL: patchURL,
+					Err: &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED},
+				})),
+		},
+		{
+			name: "bare eof",
+			err:  fmt.Errorf("copy source chunk: %w", io.EOF),
+		},
+		{
+			name: "unexpected eof",
+			err:  fmt.Errorf("copy source chunk: %w", io.ErrUnexpectedEOF),
+		},
+		{
+			name: "connection reset",
+			err:  fmt.Errorf("push: %w", &net.OpError{Op: "write", Net: "tcp", Err: syscall.ECONNRESET}),
+		},
+		{
+			name: "broken pipe",
+			err:  fmt.Errorf("push: %w", syscall.EPIPE),
+		},
+		{
+			name: "dial timeout",
+			err:  &url.Error{Op: "Get", URL: patchURL, Err: &net.OpError{Op: "dial", Err: syscall.ETIMEDOUT}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ClassifyError(test.err); got != httpapi.ErrNetwork {
+				t.Errorf("ClassifyError() = %q, want %q", got, httpapi.ErrNetwork)
+			}
+		})
+	}
+}
+
+// A registry that answered must still be classified by its answer: the network
+// check runs last so it cannot mask an auth or not-found response.
+func TestClassifyErrorRegistryResponseWins(t *testing.T) {
+	tokenURL, err := url.Parse("https://ghcr.io/token?scope=repository:x:pull")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want ErrorKind
+	}{
+		{
+			name: "unauthorized response",
+			err: fmt.Errorf("resolve: %w", &errcode.ErrorResponse{
+				Method: "GET", URL: tokenURL, StatusCode: 401,
+			}),
+			want: httpapi.ErrAuth,
+		},
+		{
+			name: "not found response",
+			err: fmt.Errorf("resolve: %w", &errcode.ErrorResponse{
+				Method: "GET", URL: tokenURL, StatusCode: 404,
+			}),
+			want: httpapi.ErrNotFound,
+		},
+		{
+			name: "server error is still network",
+			err: fmt.Errorf("resolve: %w", &errcode.ErrorResponse{
+				Method: "GET", URL: tokenURL, StatusCode: 503,
+			}),
+			want: httpapi.ErrNetwork,
+		},
+		{
+			name: "upload state failure",
+			err:  fmt.Errorf("%w: save upload state", ErrUploadStateFailure),
+			want: ErrUploadState,
+		},
+		{
+			name: "plain error stays unknown",
+			err:  fmt.Errorf("registry offset moved backwards: got=1 start=2"),
+			want: httpapi.ErrUnknown,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ClassifyError(test.err); got != test.want {
+				t.Errorf("ClassifyError() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// The failing host is recoverable from a transport error too, so a dropped
+// connection is attributed to the registry that went away.
+func TestRegistryHostFromTransportError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "harbor port-forward",
+			err: &url.Error{
+				Op:  "Patch",
+				URL: "http://127.0.0.1:5000/v2/services/llm-d/llm-d-cuda/blobs/uploads/x",
+				Err: io.EOF,
+			},
+			want: "127.0.0.1:5000",
+		},
+		{
+			name: "source registry",
+			err:  fmt.Errorf("copy source chunk: %w", &url.Error{Op: "Get", URL: "https://ghcr.io/v2/x/blobs/sha256:y", Err: io.EOF}),
+			want: "ghcr.io",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RegistryHost(test.err); got != test.want {
+				t.Errorf("RegistryHost() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/installer/internal/oras/errdef/errors.go
+++ b/installer/internal/oras/errdef/errors.go
@@ -93,6 +93,17 @@ func RegistryHost(err error) string {
 		}
 	}
 
+	// A transport failure never reaches a registry response, but the request
+	// URL survives on the *url.Error. Without this a dropped connection is
+	// unattributed and reads as a Harbor problem even when the source registry
+	// was the side that went away.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if parsed, parseErr := url.Parse(urlErr.URL); parseErr == nil {
+			return parsed.Host
+		}
+	}
+
 	return ""
 }
 

--- a/installer/internal/oras/repository/resume_test.go
+++ b/installer/internal/oras/repository/resume_test.go
@@ -1,0 +1,186 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+const testDigest = "sha256:2ff1fec5a6d4a1319b2df10ac245a89f6de043887b5ec0bb733b3dda581ba36d"
+
+func newTestRepository(t *testing.T, handler http.Handler) (*Repository, string, string, func()) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	stateDir := t.TempDir()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	repo, err := remote.NewRepository(host + "/services/llm-d/llm-d-cuda")
+	if err != nil {
+		server.Close()
+		t.Fatalf("new repository: %v", err)
+	}
+	repo.PlainHTTP = true
+	// doReq calls r.Repo.Client directly; production wires this up in
+	// client.remoteRepository.
+	repo.Client = server.Client()
+
+	return New(repo, ChunkedUploadOptions{
+		ChunkSize: 1024,
+		StateDir:  stateDir,
+		Logf:      func(string, ...any) {},
+	}), stateDir, server.URL, server.Close
+}
+
+func readState(t *testing.T, stateDir string) uploadState {
+	t.Helper()
+
+	name := strings.ReplaceAll(testDigest, ":", "-") + ".json"
+	body, err := os.ReadFile(filepath.Join(stateDir, name))
+	if err != nil {
+		t.Fatalf("read upload state: %v", err)
+	}
+
+	var state uploadState
+	if err := json.Unmarshal(body, &state); err != nil {
+		t.Fatalf("decode upload state: %v", err)
+	}
+
+	return state
+}
+
+// An upload session that the registry has expired must restart cleanly.
+//
+// The old behaviour continued with the zero values from the failed status
+// check, producing a chunk with no location. Every PATCH then failed with
+// "unsupported protocol scheme", and because the empty location was written
+// back, the state file kept the upload wedged on every later run.
+func TestStartOrResumeBlobUploadRestartsExpiredSession(t *testing.T) {
+	var posted bool
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+			// Harbor has purged the session recorded in the state file.
+			w.WriteHeader(http.StatusNotFound)
+
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/blobs/uploads/"):
+			posted = true
+			w.Header().Set("Location", "/v2/services/llm-d/llm-d-cuda/blobs/uploads/fresh-session")
+			w.WriteHeader(http.StatusAccepted)
+
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	repo, stateDir, _, closeServer := newTestRepository(t, handler)
+	defer closeServer()
+
+	desc := ocispec.Descriptor{Digest: testDigest, Size: 6557630703}
+
+	if err := repo.saveUploadState(desc, 1610612736, "http://127.0.0.1:5000/v2/services/llm-d/llm-d-cuda/blobs/uploads/expired"); err != nil {
+		t.Fatalf("seed upload state: %v", err)
+	}
+
+	current, err := repo.startOrResumeBlobUpload(context.Background(), desc)
+	if err != nil {
+		t.Fatalf("startOrResumeBlobUpload() error = %v", err)
+	}
+
+	if !posted {
+		t.Error("no new upload was started after the recorded session expired")
+	}
+	if current.Location == "" {
+		t.Fatal("resumed chunk has no location; every PATCH would fail with an empty URL")
+	}
+	if !strings.HasSuffix(current.Location, "fresh-session") {
+		t.Errorf("location = %q, want the newly posted session", current.Location)
+	}
+	if current.Offset != 0 {
+		t.Errorf("offset = %d, want 0 for a restarted upload", current.Offset)
+	}
+
+	if state := readState(t, stateDir); state.Location == "" {
+		t.Error("an empty location was written back to the state file")
+	}
+}
+
+// A state file already carrying an empty location must recover by itself
+// rather than reproducing the failure on every run.
+func TestStartOrResumeBlobUploadRecoversFromPoisonedState(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/blobs/uploads/") {
+			w.Header().Set("Location", "/v2/services/llm-d/llm-d-cuda/blobs/uploads/fresh-session")
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		t.Errorf("unexpected request %s %s: an empty location must not be requested", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	repo, _, _, closeServer := newTestRepository(t, handler)
+	defer closeServer()
+
+	desc := ocispec.Descriptor{Digest: testDigest, Size: 6557630703}
+
+	if err := repo.saveUploadState(desc, 0, ""); err != nil {
+		t.Fatalf("seed upload state: %v", err)
+	}
+
+	current, err := repo.startOrResumeBlobUpload(context.Background(), desc)
+	if err != nil {
+		t.Fatalf("startOrResumeBlobUpload() error = %v", err)
+	}
+
+	if !strings.HasSuffix(current.Location, "fresh-session") {
+		t.Errorf("location = %q, want a freshly posted session", current.Location)
+	}
+}
+
+// A live session must still resume where it left off.
+func TestStartOrResumeBlobUploadResumesLiveSession(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blobs/uploads/") {
+			w.Header().Set("Range", "0-1610612735")
+			w.Header().Set("Location", "/v2/services/llm-d/llm-d-cuda/blobs/uploads/live-session")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		t.Errorf("unexpected request %s %s: a live session must not be restarted", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	repo, _, serverURL, closeServer := newTestRepository(t, handler)
+	defer closeServer()
+
+	desc := ocispec.Descriptor{Digest: testDigest, Size: 6557630703}
+
+	live := serverURL + "/v2/services/llm-d/llm-d-cuda/blobs/uploads/live"
+	if err := repo.saveUploadState(desc, 1610612736, live); err != nil {
+		t.Fatalf("seed upload state: %v", err)
+	}
+
+	current, err := repo.startOrResumeBlobUpload(context.Background(), desc)
+	if err != nil {
+		t.Fatalf("startOrResumeBlobUpload() error = %v", err)
+	}
+
+	if current.Offset != 1610612736 {
+		t.Errorf("offset = %d, want the recorded resume point", current.Offset)
+	}
+	if !strings.HasSuffix(current.Location, "live-session") {
+		t.Errorf("location = %q, want the live session", current.Location)
+	}
+}

--- a/installer/internal/oras/repository/upload.go
+++ b/installer/internal/oras/repository/upload.go
@@ -274,6 +274,26 @@ func (r *Repository) pushBlobChunked(ctx context.Context, desc ocispec.Descripto
 	return nil
 }
 
+// resumeBlobUpload asks the registry where a recorded upload left off. An
+// error means the upload cannot be continued and the caller must start a new
+// one.
+func (r *Repository) resumeBlobUpload(ctx context.Context, state *uploadState) (chunk, error) {
+	if state.Location == "" {
+		return chunk{}, fmt.Errorf("upload state has no location")
+	}
+
+	offset, location, err := r.getBlobUpload(ctx, state.Location)
+	if err != nil {
+		return chunk{}, err
+	}
+
+	if location == "" {
+		return chunk{}, fmt.Errorf("registry returned no upload location")
+	}
+
+	return chunk{Location: location, Offset: offset}, nil
+}
+
 func (r *Repository) startOrResumeBlobUpload(ctx context.Context, desc ocispec.Descriptor) (chunk, error) {
 	state, err := r.loadUploadState(desc)
 	if err != nil {
@@ -283,22 +303,30 @@ func (r *Repository) startOrResumeBlobUpload(ctx context.Context, desc ocispec.D
 	if state != nil {
 		r.logf("oras chunk push: found upload state %s", state)
 
-		offset, location, err := r.getBlobUpload(ctx, state.Location)
-		if err != nil {
-			if err := r.deleteUploadState(desc); err != nil {
-				return chunk{}, fmt.Errorf("%w: delete stale upload state: %w", localerrdef.ErrUploadStateFailure, err)
+		resumeChunk, resumeErr := r.resumeBlobUpload(ctx, state)
+		if resumeErr == nil {
+			if err := r.saveUploadState(desc, resumeChunk.Offset, resumeChunk.Location); err != nil {
+				return chunk{}, fmt.Errorf("%w: save resumed upload state: %w", localerrdef.ErrUploadStateFailure, err)
 			}
-			r.logf("oras chunk push: deleting stale upload state digest=%s error=%v", desc.Digest, err)
+			r.logf("oras chunk push: resumed upload digest=%s offset=%d size=%d", desc.Digest, resumeChunk.Offset, desc.Size)
+
+			return resumeChunk, nil
 		}
 
-		resumeChunk := chunk{Location: location, Offset: offset}
+		// The registry no longer knows this upload: sessions expire between
+		// runs. The only way forward is a fresh upload, so the record is
+		// dropped and the POST below starts over.
+		//
+		// Falling through to the fresh POST is the point. Continuing with the
+		// zero values from the failed status check produced a chunk with no
+		// location, which then failed every PATCH with "unsupported protocol
+		// scheme" and, because that empty location was saved back, poisoned the
+		// state file so every later run repeated it.
+		r.logf("oras chunk push: discarding stale upload state digest=%s error=%v", desc.Digest, resumeErr)
 
-		if err := r.saveUploadState(desc, resumeChunk.Offset, resumeChunk.Location); err != nil {
-			return chunk{}, fmt.Errorf("%w: save resumed upload state: %w", localerrdef.ErrUploadStateFailure, err)
+		if err := r.deleteUploadState(desc); err != nil {
+			return chunk{}, fmt.Errorf("%w: delete stale upload state: %w", localerrdef.ErrUploadStateFailure, err)
 		}
-		r.logf("oras chunk push: resumed upload digest=%s offset=%d size=%d", desc.Digest, resumeChunk.Offset, desc.Size)
-
-		return resumeChunk, nil
 	}
 
 	location, err := r.postBlobUpload(ctx)

--- a/installer/internal/oras/repository/upload.go
+++ b/installer/internal/oras/repository/upload.go
@@ -120,6 +120,114 @@ func spoolChunkToTempFile(content io.ReadSeeker, offset int64, size int64) (*chu
 	return &chunkContent{size: size, open: open}, cleanup, nil
 }
 
+// chunkPrefetcher spools the next chunk while the current one is being pushed.
+//
+// Mirroring a remote image reads every chunk from the source registry into a
+// temp file before sending it to Harbor. Done inline those two transfers never
+// overlap, so a blob costs its download time plus its upload time: a 6.5 GB
+// layer measured 47.5s per 128 MiB chunk, roughly half of it spent not talking
+// to Harbor at all.
+//
+// Reads of the source stay serialized despite the goroutine: fetch always
+// drains a pending prefetch before touching the source itself, so exactly one
+// reader is active at any time. The cost is one extra chunk on disk.
+type chunkPrefetcher struct {
+	content   io.ReadSeeker
+	spool     bool
+	blobSize  int64
+	chunkSize int64
+
+	pending <-chan prefetchResult
+}
+
+type prefetchResult struct {
+	offset  int64
+	size    int64
+	content *chunkContent
+	cleanup func()
+	err     error
+}
+
+func newChunkPrefetcher(content io.ReadSeeker, blobSize int64, opts ChunkedUploadOptions) *chunkPrefetcher {
+	return &chunkPrefetcher{
+		content:   content,
+		spool:     opts.SpoolChunks,
+		blobSize:  blobSize,
+		chunkSize: opts.ChunkSize,
+	}
+}
+
+// fetch returns the content for one chunk, using the prefetched copy when it
+// covers exactly the requested range. A retry or a recovered offset moves the
+// range, and the prefetch is then discarded rather than reused.
+func (p *chunkPrefetcher) fetch(offset int64, size int64) (*chunkContent, func(), error) {
+	if pending, ok := p.take(); ok {
+		if pending.err == nil && pending.offset == offset && pending.size == size {
+			p.start(offset + size)
+			return pending.content, pending.cleanup, nil
+		}
+
+		if pending.cleanup != nil {
+			pending.cleanup()
+		}
+	}
+
+	content, cleanup, err := prepareChunkContent(p.content, offset, size, p.spool)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p.start(offset + size)
+
+	return content, cleanup, nil
+}
+
+// take blocks on an in-flight prefetch so the source has a single reader.
+func (p *chunkPrefetcher) take() (prefetchResult, bool) {
+	if p.pending == nil {
+		return prefetchResult{}, false
+	}
+
+	result := <-p.pending
+	p.pending = nil
+
+	return result, true
+}
+
+func (p *chunkPrefetcher) start(offset int64) {
+	// Only spooled chunks are worth reading ahead: a direct chunk is a section
+	// reader over an already-local file and costs nothing to open.
+	if !p.spool || p.chunkSize <= 0 || offset >= p.blobSize {
+		return
+	}
+
+	size := p.chunkSize
+	if remaining := p.blobSize - offset; remaining < size {
+		size = remaining
+	}
+
+	results := make(chan prefetchResult, 1)
+	p.pending = results
+
+	go func() {
+		content, cleanup, err := spoolChunkToTempFile(p.content, offset, size)
+		results <- prefetchResult{
+			offset:  offset,
+			size:    size,
+			content: content,
+			cleanup: cleanup,
+			err:     err,
+		}
+	}()
+}
+
+// close discards an unused prefetch so its temp file does not outlive the push.
+func (p *chunkPrefetcher) close() {
+	if pending, ok := p.take(); ok && pending.cleanup != nil {
+		pending.cleanup()
+	}
+}
+
 func (r *Repository) pushBlobChunked(ctx context.Context, desc ocispec.Descriptor, content io.ReadSeeker) error {
 	ctx = auth.AppendRepositoryScope(ctx, r.Repo.Reference, auth.ActionPull, auth.ActionPush)
 
@@ -141,10 +249,13 @@ func (r *Repository) pushBlobChunked(ctx context.Context, desc ocispec.Descripto
 	}
 	setReportedOffset(current.Offset)
 
+	prefetcher := newChunkPrefetcher(content, desc.Size, r.opts)
+	defer prefetcher.close()
+
 	for current.Offset < desc.Size {
 		current = nextChunk(current.Location, current.Offset, desc.Size, r.opts.ChunkSize)
 
-		if err := r.uploadChunkWithRetry(ctx, &current, desc, content, func() { setReportedOffset(0) }); err != nil {
+		if err := r.uploadChunkWithRetry(ctx, &current, desc, prefetcher, func() { setReportedOffset(0) }); err != nil {
 			return err
 		}
 
@@ -205,7 +316,7 @@ func (r *Repository) startOrResumeBlobUpload(ctx context.Context, desc ocispec.D
 	return newChunk, nil
 }
 
-func (r *Repository) uploadChunkWithRetry(ctx context.Context, current *chunk, desc ocispec.Descriptor, content io.ReadSeeker, onRestart func()) error {
+func (r *Repository) uploadChunkWithRetry(ctx context.Context, current *chunk, desc ocispec.Descriptor, prefetcher *chunkPrefetcher, onRestart func()) error {
 	var lastErr error
 
 	for attempt := 1; attempt <= r.opts.MaxChunkAttempts; attempt++ {
@@ -219,7 +330,7 @@ func (r *Repository) uploadChunkWithRetry(ctx context.Context, current *chunk, d
 			return fmt.Errorf("invalid remaining chunk range offset=%d end=%d", current.Offset, current.End)
 		}
 
-		chunkBody, cleanup, err := prepareChunkContent(content, attemptOffset, attemptSize, r.opts.SpoolChunks)
+		chunkBody, cleanup, err := prefetcher.fetch(attemptOffset, attemptSize)
 		if err != nil {
 			lastErr = err
 

--- a/installer/internal/oras/repository/upload_test.go
+++ b/installer/internal/oras/repository/upload_test.go
@@ -1,0 +1,202 @@
+package repository
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testBlob(size int) []byte {
+	blob := make([]byte, size)
+	for i := range blob {
+		blob[i] = byte(i % 251)
+	}
+	return blob
+}
+
+func readChunk(t *testing.T, content *chunkContent) []byte {
+	t.Helper()
+
+	reader, err := content.Open()
+	if err != nil {
+		t.Fatalf("open chunk: %v", err)
+	}
+	defer reader.Close()
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+
+	return body
+}
+
+func tempFileCount(t *testing.T) int {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "oras-chunk-*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+
+	return len(matches)
+}
+
+// Walking a blob chunk by chunk must return the same bytes the source holds,
+// whether a chunk came from the prefetch or was spooled on the spot.
+func TestChunkPrefetcherServesEveryChunk(t *testing.T) {
+	const chunkSize = 1024
+	blob := testBlob(chunkSize*3 + 500)
+
+	for _, spool := range []bool{true, false} {
+		name := "spooled"
+		if !spool {
+			name = "direct"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			prefetcher := newChunkPrefetcher(
+				bytes.NewReader(blob),
+				int64(len(blob)),
+				ChunkedUploadOptions{ChunkSize: chunkSize, SpoolChunks: spool},
+			)
+			defer prefetcher.close()
+
+			for offset := 0; offset < len(blob); offset += chunkSize {
+				size := chunkSize
+				if remaining := len(blob) - offset; remaining < size {
+					size = remaining
+				}
+
+				content, cleanup, err := prefetcher.fetch(int64(offset), int64(size))
+				if err != nil {
+					t.Fatalf("fetch(%d, %d): %v", offset, size, err)
+				}
+
+				if got := readChunk(t, content); !bytes.Equal(got, blob[offset:offset+size]) {
+					t.Fatalf("chunk at offset %d does not match the source", offset)
+				}
+
+				cleanup()
+			}
+		})
+	}
+}
+
+// A retry or a recovered offset asks for a range the prefetch does not cover.
+// The stale copy must be discarded, not served.
+func TestChunkPrefetcherDiscardsMismatchedRange(t *testing.T) {
+	const chunkSize = 1024
+	blob := testBlob(chunkSize * 4)
+
+	prefetcher := newChunkPrefetcher(
+		bytes.NewReader(blob),
+		int64(len(blob)),
+		ChunkedUploadOptions{ChunkSize: chunkSize, SpoolChunks: true},
+	)
+	defer prefetcher.close()
+
+	content, cleanup, err := prefetcher.fetch(0, chunkSize)
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	cleanup()
+	_ = content
+
+	// The registry accepted part of the chunk, so the next range starts inside
+	// what was prefetched rather than at the chunk boundary.
+	const recoveredOffset = chunkSize + 256
+	const recoveredSize = chunkSize - 256
+
+	recovered, cleanup, err := prefetcher.fetch(recoveredOffset, recoveredSize)
+	if err != nil {
+		t.Fatalf("recovered fetch: %v", err)
+	}
+	defer cleanup()
+
+	want := blob[recoveredOffset : recoveredOffset+recoveredSize]
+	if got := readChunk(t, recovered); !bytes.Equal(got, want) {
+		t.Fatalf("recovered chunk does not match the source range")
+	}
+}
+
+// The point of the prefetch: the next chunk is read from the source while the
+// caller is still busy with the current one.
+func TestChunkPrefetcherReadsAhead(t *testing.T) {
+	const chunkSize = 1024
+	blob := testBlob(chunkSize * 2)
+
+	source := &slowReader{ReadSeeker: bytes.NewReader(blob), delay: 40 * time.Millisecond}
+	prefetcher := newChunkPrefetcher(
+		source,
+		int64(len(blob)),
+		ChunkedUploadOptions{ChunkSize: chunkSize, SpoolChunks: true},
+	)
+	defer prefetcher.close()
+
+	first, cleanup, err := prefetcher.fetch(0, chunkSize)
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	_ = first
+	cleanup()
+
+	// Stand in for the upload of chunk one; the second chunk should be spooled
+	// during this window rather than after it.
+	time.Sleep(80 * time.Millisecond)
+
+	start := time.Now()
+	second, cleanup, err := prefetcher.fetch(chunkSize, chunkSize)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	defer cleanup()
+	elapsed := time.Since(start)
+
+	if elapsed > 20*time.Millisecond {
+		t.Errorf("second fetch took %v; it was not read ahead", elapsed)
+	}
+	if got := readChunk(t, second); !bytes.Equal(got, blob[chunkSize:]) {
+		t.Fatalf("prefetched chunk does not match the source")
+	}
+}
+
+// An abandoned prefetch must not leave its temp file behind.
+func TestChunkPrefetcherCloseRemovesPendingSpool(t *testing.T) {
+	const chunkSize = 1024
+	blob := testBlob(chunkSize * 4)
+
+	before := tempFileCount(t)
+
+	prefetcher := newChunkPrefetcher(
+		bytes.NewReader(blob),
+		int64(len(blob)),
+		ChunkedUploadOptions{ChunkSize: chunkSize, SpoolChunks: true},
+	)
+
+	_, cleanup, err := prefetcher.fetch(0, chunkSize)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	cleanup()
+
+	// A pending prefetch for the second chunk is now in flight and never taken.
+	prefetcher.close()
+
+	if after := tempFileCount(t); after != before {
+		t.Errorf("temp file count = %d, want %d: a spooled chunk was leaked", after, before)
+	}
+}
+
+type slowReader struct {
+	io.ReadSeeker
+	delay time.Duration
+}
+
+func (r *slowReader) Read(p []byte) (int, error) {
+	time.Sleep(r.delay)
+	return r.ReadSeeker.Read(p)
+}

--- a/installer/internal/workflow/stages/discovery/discovery.go
+++ b/installer/internal/workflow/stages/discovery/discovery.go
@@ -347,6 +347,7 @@ func startPortForward(rt *core.Runtime) error {
 			LocalPort:  rt.Bootstrap.Config.Harbor.LocalPort,
 			RemotePort: rt.Discovery.Target.TargetPort,
 			PodName:    rt.Discovery.Target.PodName,
+			Logf:       rt.Detailf,
 		},
 	)
 	if err != nil {

--- a/pkg/kube/forward.go
+++ b/pkg/kube/forward.go
@@ -6,11 +6,24 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+)
+
+const (
+	// A port-forward is a SPDY stream held open through the API server, and on
+	// managed clusters the tunnel in front of it drops long-lived transfers.
+	// Multi-GB blob uploads run far longer than such a stream reliably
+	// survives, so the forward reconnects instead of leaving the caller with a
+	// closed listener and a refused connection.
+	defaultReconnectAttempts = 10
+	defaultReconnectDelay    = 2 * time.Second
+	maxReconnectDelay        = 30 * time.Second
+	reconnectTimeout         = 30 * time.Second
 )
 
 func StartPortForward(
@@ -19,6 +32,50 @@ func StartPortForward(
 	client kubernetes.Interface,
 	target ForwardRequest,
 ) (*Forward, error) {
+	session, err := startForwardSession(ctx, restCfg, client, target)
+	if err != nil {
+		return nil, err
+	}
+
+	forward := &Forward{
+		localPort: session.localPort,
+		stopCh:    make(chan struct{}),
+		doneCh:    make(chan struct{}),
+		logf:      target.Logf,
+	}
+
+	// Later sessions must land on the same local port: the callers that hold
+	// this address have already handed it to an HTTP client, and a reconnect
+	// that moved the port would silently stop serving them.
+	target.LocalPort = int(session.localPort)
+
+	// The caller's context carries the dial deadline for the first connect and
+	// is cancelled as soon as it returns. Reconnects outlive that by design, so
+	// the supervisor keeps the values and drops the cancellation, and bounds
+	// each attempt with a deadline of its own.
+	go forward.supervise(context.WithoutCancel(ctx), restCfg, client, target, session)
+
+	return forward, nil
+}
+
+type forwardSession struct {
+	localPort uint16
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+	errCh     chan error
+}
+
+func (s *forwardSession) close() {
+	close(s.stopCh)
+	<-s.doneCh
+}
+
+func startForwardSession(
+	ctx context.Context,
+	restCfg *rest.Config,
+	client kubernetes.Interface,
+	target ForwardRequest,
+) (*forwardSession, error) {
 	url := client.CoreV1().RESTClient().
 		Post().
 		Resource("pods").
@@ -67,34 +124,34 @@ func StartPortForward(
 			}
 		}
 	}()
+
+	fail := func(err error) (*forwardSession, error) {
+		close(stopCh)
+		<-doneCh
+		return nil, err
+	}
+
 	select {
 	case <-readyCh:
 	case err := <-errCh:
-		close(stopCh)
-		<-doneCh
-		return nil, fmt.Errorf("start port-forward: %w", err)
+		return fail(fmt.Errorf("start port-forward: %w", err))
 	case <-ctx.Done():
-		close(stopCh)
-		<-doneCh
-		return nil, fmt.Errorf("wait for port forward: %w", ctx.Err())
+		return fail(fmt.Errorf("wait for port forward: %w", ctx.Err()))
 	}
 
 	ports, err := forwarder.GetPorts()
 	if err != nil {
-		close(stopCh)
-		<-doneCh
-		return nil, fmt.Errorf("read forwarded ports: %w", err)
+		return fail(fmt.Errorf("read forwarded ports: %w", err))
 	}
 	if len(ports) != 1 {
-		close(stopCh)
-		<-doneCh
-		return nil, fmt.Errorf("expected 1 forwarded port, got %d", len(ports))
+		return fail(fmt.Errorf("expected 1 forwarded port, got %d", len(ports)))
 	}
 
-	return &Forward{
+	return &forwardSession{
 		localPort: ports[0].Local,
 		stopCh:    stopCh,
 		doneCh:    doneCh,
+		errCh:     errCh,
 	}, nil
 }
 
@@ -103,6 +160,8 @@ type Forward struct {
 	stopCh    chan struct{}
 	doneCh    chan struct{}
 	closeOnce sync.Once
+
+	logf func(format string, args ...any)
 }
 
 type ForwardRequest struct {
@@ -111,6 +170,128 @@ type ForwardRequest struct {
 	PodName    string
 	LocalPort  int
 	RemotePort int
+
+	// Logf receives reconnect messages. Optional.
+	Logf func(format string, args ...any)
+}
+
+// supervise replaces the session whenever it ends on its own. ForwardPorts
+// returning takes the local listener with it, so without this the first
+// symptom of a dropped tunnel is a refused connection on the next request,
+// with no way back short of restarting the step.
+func (f *Forward) supervise(
+	ctx context.Context,
+	restCfg *rest.Config,
+	client kubernetes.Interface,
+	target ForwardRequest,
+	session *forwardSession,
+) {
+	defer close(f.doneCh)
+
+	for {
+		select {
+		case <-f.stopCh:
+			session.close()
+			return
+
+		case <-ctx.Done():
+			session.close()
+			return
+
+		case <-session.doneCh:
+			// The forwarder exited. Closing was requested concurrently in the
+			// race where both fire, and then there is nothing to reconnect.
+			select {
+			case <-f.stopCh:
+				return
+			default:
+			}
+
+			f.log("port-forward %s:%d dropped: %v", target.PodName, target.LocalPort, sessionError(session))
+
+			next, err := f.reconnect(ctx, restCfg, client, target)
+			if err != nil {
+				f.log("port-forward %s:%d could not be re-established: %v", target.PodName, target.LocalPort, err)
+				return
+			}
+
+			f.log("port-forward %s:%d re-established", target.PodName, target.LocalPort)
+			session = next
+		}
+	}
+}
+
+func (f *Forward) reconnect(
+	ctx context.Context,
+	restCfg *rest.Config,
+	client kubernetes.Interface,
+	target ForwardRequest,
+) (*forwardSession, error) {
+	delay := defaultReconnectDelay
+
+	var lastErr error
+	for attempt := 1; attempt <= defaultReconnectAttempts; attempt++ {
+		if err := f.wait(ctx, delay); err != nil {
+			return nil, err
+		}
+
+		session, err := f.connect(ctx, restCfg, client, target)
+		if err == nil {
+			return session, nil
+		}
+
+		lastErr = err
+		f.log("port-forward reconnect attempt %d/%d failed: %v", attempt, defaultReconnectAttempts, err)
+
+		if delay < maxReconnectDelay {
+			delay *= 2
+		}
+	}
+
+	return nil, fmt.Errorf("after %d attempts: %w", defaultReconnectAttempts, lastErr)
+}
+
+func (f *Forward) connect(
+	ctx context.Context,
+	restCfg *rest.Config,
+	client kubernetes.Interface,
+	target ForwardRequest,
+) (*forwardSession, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, reconnectTimeout)
+	defer cancel()
+
+	return startForwardSession(attemptCtx, restCfg, client, target)
+}
+
+func (f *Forward) wait(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-f.stopCh:
+		return fmt.Errorf("port-forward closed")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (f *Forward) log(format string, args ...any) {
+	if f.logf == nil {
+		return
+	}
+
+	f.logf(format, args...)
+}
+
+func sessionError(session *forwardSession) error {
+	select {
+	case err := <-session.errCh:
+		return err
+	default:
+		return fmt.Errorf("connection closed")
+	}
 }
 
 func (f *Forward) LocalPort() uint16 {


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

[SHD-1016](https://axem.atlassian.net/browse/SHD-1016)

## Description

Mirroring a huge image (`llm-d/llm-d-cuda`) into Harbor on AKS failed three
times in different ways. Four fixes, all on the path between a source registry
and Harbor.

**1. Transport failures are classified as network errors.** A dropped connection
reached `errdef.ClassifyError` as a bare `*url.Error`, matched none of the
registry-response branches, and fell through to an unknown kind, which the
artifact recovery treats as fatal. The run aborted with resumable state on disk
that would have continued the blob from 1.6 GB. `httpapi.ClassifyError` has
always drawn this distinction; the oras path now does too. The check runs after
the response branches, so a registry that answered is still classified by its
answer. `RegistryHost` also reads the URL off a `*url.Error`, so these failures
name the side that went away rather than always reading as a Harbor problem.

**2. The port-forward re-establishes itself.** `ForwardPorts` returning takes the
local listener with it, so the first symptom of a dropped tunnel was a refused
connection on the next request. The forward already built an error channel and a
done channel; nothing read them after startup. A supervisor now replaces the
session when it ends on its own. Reconnects are logged.

The supervisor takes `context.WithoutCancel` of the caller's context:
`EnsurePortForward` passes a 30-second dial deadline and cancels it on return, so
inheriting it directly would kill the forward immediately. Each reconnect attempt
gets its own deadline instead.

Paired with it, a 2-minute `ResponseHeaderTimeout` on the oras transport. The
clock starts after the request body is written, so it does not cap chunk upload
time; it stops the unbounded wait before the chunk retry could begin.

**3. The next chunk is spooled while the current one uploads.** Mirroring a remote
image reads every chunk into a temp file before sending it to Harbor, and inline
those two transfers never overlap. `chunkPrefetcher` reads one chunk
ahead. Source reads stay serialized despite the goroutine. `fetch` drains a
pending prefetch before touching the source itself, so exactly one reader is
active at any time. A retry or a recovered offset asks for a different range, and
the stale copy is discarded rather than served. Cost is one extra chunk on disk.

**4. An expired upload session restarts.** When the status check for a recorded
session failed, the state was deleted, but the upload continued with the zero
values from that failed call, so it proceeded with no location and every PATCH
failed with `unsupported protocol scheme ""`. That empty location was then written
back, so every later run reloaded it and repeated the failure. The blob could not
be uploaded again until the state file was deleted by hand, and rebuilding the
image did not clear it. Resolving the resume point and starting a new upload are
now separate, and a state file already carrying an empty location self-heals.

## Validation

- [x] Changed Go files were formatted with `gofmt`.
- [x] `go test ./...` passed in every affected Go module.

Additional validation details:

- `go build ./...` and `go test ./...` pass in both the `installer` and `pkg`
  modules. `go test -race ./internal/oras/...` passes, which matters because the
  prefetcher introduces a goroutine.
- Classifier tests use the literal error shape from the failing run: a PATCH
  `*url.Error` wrapping `io.EOF`, joined with a status check wrapping
  `ECONNREFUSED`. Sibling cases assert 401/404/503 responses and upload-state
  failures still classify as before, and that a plain error stays unknown.
- Prefetcher tests cover chunk contents in spooled and direct modes, discarding a
  prefetch when a recovered offset moves the range, temp files not leaking on an
  abandoned prefetch, and that the read-ahead actually overlaps.
- Resume tests run against an `httptest` registry: an expired session restarts and
  POSTs a new upload, a poisoned state file recovers without ever requesting the
  empty URL, and a live session still resumes at its recorded offset.
- Both new behaviours were confirmed to fail when reverted: stubbing out the
  prefetch fails with "it was not read ahead", and restoring the original
  fallthrough fails the expired-session test.
- `go vet ./...` in `pkg` reports one pre-existing warning in
  `pkg/kube/daemon.go:166` (unkeyed fields), untouched by this branch.

## Deployment and operational impact

No configuration or rollout changes. Behavioural notes for operators:

- A dropped connection during an upload now offers Retry instead of ending the
  run, and retrying resumes from the recorded offset.
- The port-forward reconnects silently up to 10 times; reconnects appear in the
  installer log.
- Chunk read-ahead holds one extra 128 MiB chunk in `TMPDIR` during an upload.
- Anyone already wedged by problem 4 should delete the affected file under
  `<storage>/upload-state/` once, or let the first run on this build clear it.

## Documentation

None needed. No documented configuration, topology, or operator workflow changed.

## Checklist

- [x] I added or updated tests for changed behavior, or explained why tests are not needed.
- [ ] I updated documentation for deployment, configuration, topology, or operational changes. (No documented behaviour changed.)
- [x] My commits follow the Conventional Commits specification.
- [x] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.


[SHD-1016]: https://axem.atlassian.net/browse/SHD-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ