### PR TITLE
fix(installer): skip app-serving when no models are selected

### DIFF
--- a/installer/internal/workflow/stages/pulumi/pulumi.go
+++ b/installer/internal/workflow/stages/pulumi/pulumi.go
@@ -16,6 +16,7 @@ func Stage() core.Stage {
 			},
 			{
 				Name:    "Deploy App-Serving ",
+				When:    stacks.ServesModels,
 				Run:     stacks.DeployAppServing,
 				Recover: RecoverAppServing,
 			},

--- a/installer/internal/workflow/stages/pulumi/pulumi_test.go
+++ b/installer/internal/workflow/stages/pulumi/pulumi_test.go
@@ -1,0 +1,76 @@
+package pulumi
+
+import (
+	"testing"
+
+	"github.com/axem-solutions/ai_platform/installer/internal/config/catalog"
+	"github.com/axem-solutions/ai_platform/installer/internal/workflow/core"
+)
+
+func stepNamed(t *testing.T, name string) core.Step {
+	t.Helper()
+
+	for _, step := range Stage().Steps {
+		if step.Name == name {
+			return step
+		}
+	}
+
+	t.Fatalf("stage has no step named %q", name)
+	return core.Step{}
+}
+
+func runtimeWithModels(models []catalog.Model) *core.Runtime {
+	rt := &core.Runtime{
+		GlobalState:      core.NewGlobalState(),
+		ActiveStageState: core.NewActiveStageState(),
+	}
+	rt.Bootstrap.Catalog.Models = models
+
+	return rt
+}
+
+// A cluster that serves no models must not reach the app-serving stack: it
+// refuses to configure without one, and that failure ends the whole run before
+// App-Shaide and Monitoring are deployed.
+func TestAppServingIsSkippedWithoutModels(t *testing.T) {
+	step := stepNamed(t, "Deploy App-Serving ")
+
+	if step.When == nil {
+		t.Fatal("the app-serving step has no condition; it would run with nothing to serve")
+	}
+
+	tests := []struct {
+		name   string
+		models []catalog.Model
+		want   bool
+	}{
+		{name: "no models selected", models: nil, want: false},
+		{name: "empty selection", models: []catalog.Model{}, want: false},
+		{
+			name:   "one model selected",
+			models: []catalog.Model{{ID: "nomic-ai/nomic-embed-text-v1.5"}},
+			want:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := step.When(runtimeWithModels(test.models)); got != test.want {
+				t.Errorf("When() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// Skipping serving must not skip the rest of the platform: those stacks are
+// what a cluster with no on-cluster models still needs.
+func TestOtherStacksAreNotGatedOnModels(t *testing.T) {
+	for _, name := range []string{"Deploy Gateway Provider", "Deploy App-Shaide ", "Deploy Monitoring"} {
+		t.Run(name, func(t *testing.T) {
+			if step := stepNamed(t, name); step.When != nil {
+				t.Errorf("%q is gated; it should run regardless of the model selection", name)
+			}
+		})
+	}
+}

--- a/installer/internal/workflow/stages/pulumi/stacks/serving.go
+++ b/installer/internal/workflow/stages/pulumi/stacks/serving.go
@@ -27,6 +27,21 @@ const (
 	servingModeRecreate = "Recreate — destroy the stack, deleting model volumes"
 )
 
+// ServesModels reports whether anything is selected to serve on the cluster.
+//
+// An empty selection is a valid deployment, not a misconfiguration: a cluster
+// with no GPU nodes that reaches third-party providers only needs the rest of
+// the platform and no serving stack. The stack itself refuses to configure
+// without at least one model ("models must be non-empty"), and that failure is
+// unrecoverable, so the whole install used to stop here rather than skipping a
+// stack it had nothing to put in.
+//
+// The model manifest stands in for the model selection UI: it lists the models
+// the operator would have picked, so its being empty is the selection.
+func ServesModels(rt *core.Runtime) bool {
+	return len(rt.Bootstrap.Catalog.Models) > 0
+}
+
 func DeployAppServing(rt *core.Runtime) error {
 	workDir := filepath.Join(rt.Bootstrap.Config.Paths.ProjectsDir, projectAppServing)
 	stateDir := rt.Bootstrap.Config.Paths.PulumiState


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

[SHD-1018](https://axem.atlassian.net/browse/SHD-1018)

## Description

A cluster that serves no models on-cluster could not finish an install. The
app-serving step always ran, the stack refuses to configure without at least one
model, and a Pulumi runtime error offers no retry or skip, so the run ended
there and App-Shaide and Monitoring never deployed.

```
Step 2/4: Deploy App-Serving
pulumi:pulumi:Stack (app-serving-serving):
  error: an unhandled error occurred: 1 error occurred:
  * models must be non-empty
failed: deploy AI platform: Deploy App-Serving
```

An empty selection is a valid deployment. 
A cluster with no GPU nodes that reaches third-party providers only needs the rest
of the platform and no serving stack. The step is now gated on the selection:

```go
{
    Name:    "Deploy App-Serving ",
    When:    stacks.ServesModels,
    Run:     stacks.DeployAppServing,
    Recover: RecoverAppServing,
},
```

`ServesModels` reads the model catalog rather than what was transferred this run,
so models already present in Harbor still count. The model manifest currently
stands in for the model selection UI: it lists the models the operator would have
picked, so an empty manifest is the selection, and that reasoning is recorded on
the function rather than left for a reader to reconstruct.

## Validation

- [x] Changed Go files were formatted with `gofmt`.
- [x] `go test ./...` passed in every affected Go module.

Additional validation details:

- `go build ./...`, `go vet ./...` and `go test ./...` pass in the `installer` module.
- Verified on a live install against an AKS cluster with an empty model manifest:
  the step logged `skipped` and the run advanced to App-Shaide.

## Deployment and operational impact

No configuration changes. A cluster with no models selected now skips the
app-serving stack instead of failing the run.

Known limitation, called out because it matters for update runs: this skips the
stack, it does not remove one. A cluster where serving had previously deployed
successfully and whose models were then all deselected keeps the old deployment
rather than having it destroyed. Making an empty selection mean removal needs the
existing `Destroy` path in `DeployAppServing`, conditioned on the stack actually
holding resources, and is intentionally not part of this change.

## Documentation

None needed. No documented configuration, topology, or operator workflow changed.

## Checklist

- [x] I added or updated tests for changed behavior, or explained why tests are not needed.
- [ ] I updated documentation for deployment, configuration, topology, or operational changes. (No documented behaviour changed.)
- [x] My commits follow the Conventional Commits specification.
- [x] Every commit includes a `Signed-off-by` trailer (`git commit -s`).
- [x] I did not commit Pulumi state, kubeconfigs, chart archives, model artifacts, credentials, tokens, or plaintext secrets.

[SHD-1018]: https://axem.atlassian.net/browse/SHD-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ